### PR TITLE
feat: add podcast rendering and update resource detail page to suppor…

### DIFF
--- a/client/css/resources.css
+++ b/client/css/resources.css
@@ -697,7 +697,7 @@
   gap: var(--space-6);
 }
 
-/* Audio & Podcast */
+/* Audio */
 .media-layout {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -736,6 +736,108 @@
   color: var(--color-primary);
   font-weight: 500;
   font-size: var(--font-size-sm);
+}
+
+/* Podcast */
+.podcast-layout {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: var(--space-10);
+  max-width: 1280px;
+  margin-inline: auto;
+  padding-block: var(--space-6);
+}
+
+.podcast-main-col {
+  display: flex;
+  flex-direction: column;
+}
+
+.podcast-kicker {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  height: 26px;
+  padding: 0 var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--color-brand-900);
+  color: var(--color-white);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  margin-bottom: var(--space-4);
+}
+
+.podcast-episode-title {
+  font-family: var(--font-heading);
+  font-size: clamp(var(--font-size-2xl), 3.2vw, var(--font-size-3xl));
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--color-brand-900);
+  margin-bottom: var(--space-3);
+}
+
+.podcast-meta {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  margin-bottom: var(--space-6);
+}
+
+.podcast-player-box {
+  background: linear-gradient(135deg, var(--color-brand-900) 0%, var(--color-brand-700) 100%);
+  min-height: 180px;
+}
+
+.podcast-player-box .custom-audio {
+  max-width: 100%;
+}
+
+.podcast-actions {
+  padding-top: var(--space-2);
+}
+
+.podcast-copycat-col {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  padding: var(--space-6);
+}
+
+.podcast-copycat-title {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--color-brand-900);
+  margin-bottom: var(--space-5);
+}
+
+.podcast-copycat-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-4);
+}
+
+.podcast-copycat-item {
+  border-left: 3px solid var(--color-primary);
+  padding-left: var(--space-4);
+}
+
+.podcast-copycat-index {
+  display: inline-block;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  margin-bottom: var(--space-2);
+}
+
+.podcast-copycat-text {
+  margin: 0;
+  color: var(--color-text);
+  line-height: 1.6;
 }
 
 /* Myth-Busting */
@@ -901,6 +1003,7 @@
   }
 
   .info-grid { grid-template-columns: repeat(3, 1fr); }
+  .podcast-layout { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 768px) {
@@ -943,8 +1046,9 @@
   }
 
 
-  .myth-layout, .media-layout { grid-template-columns: 1fr; }
+  .myth-layout, .media-layout, .podcast-layout { grid-template-columns: 1fr; }
   .info-grid { grid-template-columns: repeat(2, 1fr); }
   .audio-player-box { height: 200px; }
+  .podcast-copycat-col { padding: var(--space-5); }
   .content-canvas { padding: var(--space-8) var(--space-5); }
 }

--- a/client/js/components/renderers.js
+++ b/client/js/components/renderers.js
@@ -109,20 +109,37 @@ export function renderInfographic(resource) {
   `;
 }
 
-// Media/Audio renderer 
+function renderAudioPlayer(fileUrl) {
+  return fileUrl
+    ? `<audio controls class="custom-audio"><source src="${fileUrl}" type="audio/mpeg"></audio>`
+    : `<p>Audio unavailable.</p>`;
+}
+
+function renderShareButton() {
+  return `
+    <button class="btn-share share-btn" type="button">
+      Share
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
+    </button>
+  `;
+}
+
+// Audio renderer
 export function renderMedia(resource) {
   if (!resource || !resource.structured_content) return `<p>Content unavailable.</p>`;
   const data = resource.structured_content;
+  const summaryParagraphs = Array.isArray(data.summary_paragraphs) ? data.summary_paragraphs : [];
+  const audioPlayer = renderAudioPlayer(resource.file_url);
 
-  const audioPlayer = resource.file_url
-    ? `<audio controls class="custom-audio"><source src="${resource.file_url}" type="audio/mpeg"></audio>` 
-    : `<p>Audio unavailable.</p>`;
+  const summaryContent = summaryParagraphs.length
+    ? summaryParagraphs.map((paragraph) => `<p class="content-paragraph">${paragraph}</p>`).join('')
+    : `<p class="content-paragraph">This audio has no summary yet.</p>`;
 
   return `
     <article class="media-layout content-canvas">
       <div class="media-text-col">
         <h2 class="col-title">Summary</h2>
-        ${data.summary_paragraphs.map(p => `<p class="content-paragraph">${p}</p>`).join('')}
+        ${summaryContent}
       </div>
       
       <div class="media-player-col">
@@ -134,12 +151,60 @@ export function renderMedia(resource) {
             Download now
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
           </a>
-          <button class="btn-share share-btn" type="button">
-            Share
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
-          </button>
+          ${renderShareButton()}
         </div>
       </div>
+    </article>
+  `;
+}
+
+// Podcast renderer
+export function renderPodcast(resource) {
+  if (!resource || !resource.structured_content) return `<p>Content unavailable.</p>`;
+  const data = resource.structured_content;
+  const summaryParagraphs = Array.isArray(data.summary_paragraphs) ? data.summary_paragraphs : [];
+  const audioPlayer = renderAudioPlayer(resource.file_url);
+
+  const highlights = summaryParagraphs.length
+    ? summaryParagraphs.map((paragraph, index) => `
+      <li class="podcast-copycat-item">
+        <span class="podcast-copycat-index">Moment ${index + 1}</span>
+        <p class="podcast-copycat-text">${paragraph}</p>
+      </li>
+    `).join('')
+    : `
+      <li class="podcast-copycat-item">
+        <span class="podcast-copycat-index">Moment</span>
+        <p class="podcast-copycat-text">Episode highlights will appear here.</p>
+      </li>
+    `;
+
+  return `
+    <article class="podcast-layout content-canvas">
+      <section class="podcast-main-col">
+        <p class="podcast-kicker">Now Playing</p>
+        <h2 class="podcast-episode-title">${resource.title}</h2>
+        <p class="podcast-meta">${resource.date || 'Latest release'} · ${resource.read_time || 'Podcast episode'}</p>
+
+        <div class="audio-player-box podcast-player-box">
+          ${audioPlayer}
+        </div>
+
+        <div class="media-actions podcast-actions">
+          <a href="${resource.file_url || '#'}" download target="_blank" class="btn btn-primary">
+            Download episode
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+          </a>
+          ${renderShareButton()}
+        </div>
+      </section>
+
+      <aside class="podcast-copycat-col" aria-label="Episode copy">
+        <h3 class="podcast-copycat-title">Copycat Highlights</h3>
+        <ol class="podcast-copycat-list">
+          ${highlights}
+        </ol>
+      </aside>
     </article>
   `;
 }

--- a/client/js/pages/resources-detail-page.js
+++ b/client/js/pages/resources-detail-page.js
@@ -1,5 +1,5 @@
 import { fetchResourceById } from "../data/resources-api.js";
-import { renderArticle, renderInfographic, renderMedia, renderMythBusting } from "../components/renderers.js";
+import { renderArticle, renderInfographic, renderMedia, renderMythBusting, renderPodcast } from "../components/renderers.js";
 import { renderRelatedResources } from "../components/relatedResources.js";
 import { renderCrisisStrip } from "../components/crisisStrip.js";
 import { renderNavbar, initNavbar } from "../components/navbar.js";
@@ -83,8 +83,10 @@ function populateContent(resource) {
       html = renderInfographic(resource);
       break;
     case 'audio':
-    case 'podcast':
       html = renderMedia(resource);
+      break;
+    case 'podcast':
+      html = renderPodcast(resource);
       break;
     case 'myth-busting':
       html = renderMythBusting(resource);


### PR DESCRIPTION
This pull request introduces a dedicated podcast renderer and associated styles to improve the display and user experience for podcast resources. It separates podcast presentation from generic audio, adds a new layout and visual components for podcasts, and ensures responsive design across devices.

**Podcast rendering and UI enhancements:**

* Added a new `renderPodcast` function in `renderers.js` to provide a specialized layout for podcast resources, including episode metadata, a "Now Playing" kicker, and a highlights section ("Copycat Highlights") for episode summaries. (F391bfe7L151R151)
* Updated `resources-detail-page.js` to use the new `renderPodcast` function when displaying podcast resources, ensuring podcasts are rendered with the new layout instead of the generic audio renderer. [[1]](diffhunk://#diff-16c4c638179b3d686dd6b6272809b3ffaa574a8b354cdc61c67cbc1b5d886f9dL2-R2) [[2]](diffhunk://#diff-16c4c638179b3d686dd6b6272809b3ffaa574a8b354cdc61c67cbc1b5d886f9dL86-R90)

**CSS and responsive design:**

* Added new CSS classes in `resources.css` for podcast-specific layouts and components, such as `.podcast-layout`, `.podcast-main-col`, `.podcast-kicker`, and highlights styling, to visually distinguish podcasts from other media types.
* Updated responsive CSS rules to ensure the new podcast layout adapts well to different screen sizes, including single-column layouts on smaller screens and adjusted padding for podcast highlight sections. [[1]](diffhunk://#diff-53ce333f3b7ec8dcc57fc725a9f941fa8454f79e19afbaf49294a5a25786cc2dR1006) [[2]](diffhunk://#diff-53ce333f3b7ec8dcc57fc725a9f941fa8454f79e19afbaf49294a5a25786cc2dL946-R1052)

**Audio and share button code improvements:**

* Refactored audio player and share button rendering into reusable functions (`renderAudioPlayer` and `renderShareButton`) in `renderers.js`, improving code clarity and reuse for both audio and podcast layouts. [[1]](diffhunk://#diff-6e94bf56bc023565c775014b12eb28aa3e15ecc738de92755b409ab189355742L112-R142) [[2]](diffhunk://#diff-6e94bf56bc023565c775014b12eb28aa3e15ecc738de92755b409ab189355742L137-R211)…t podcasts