### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,65 @@
+---
+name: Bug Report
+about: Report a defect in Bloom After
+title: "[Bug] <short task name>"
+labels: ["bug"]
+assignees: []
+---
+
+## Task Name
+
+<!-- A short, clear name for this bug. Example: Story form fails to submit on mobile -->
+
+## Summary
+
+<!-- One or two sentences describing the problem. -->
+
+## Area Affected
+
+- [ ] Frontend (HTML / CSS / JavaScript)
+- [ ] Backend (Node.js / Express / Supabase)
+- [ ] Admin / Moderation
+- [ ] Content / Clinical
+- [ ] Other
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behaviour
+
+<!-- What should happen. -->
+
+## Actual Behaviour
+
+<!-- What actually happens. Include console errors if any. -->
+
+## Environment
+
+- Device / Browser:
+- Screen width (e.g. 360px):
+- Branch / environment:
+
+## Acceptance Criteria (Fix Definition)
+
+- [ ] Bug no longer reproduces with the steps above
+- [ ] No new console errors introduced
+- [ ] Responsive layout still works at 360px width
+
+## Branch
+
+<!-- Branch this fix from `dev`. -->
+
+Branch name: `fix/<name>`
+
+## Linked Pull Request
+
+<!-- Link the PR once opened. Use "Closes #<this-issue-number>" in the PR to auto-close. -->
+
+PR: #
+
+## Additional Context
+
+<!-- Screenshots, logs, or anything else useful. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contribution Guidelines
+    url: https://github.com/Tabi-Project/Bloom-After/blob/main/CONTRIBUTING.md
+    about: Read the contribution workflow, coding standards, and ethical requirements before opening an issue.

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,75 @@
+---
+name: Task / Feature
+about: Propose a feature or development task for Bloom After
+title: "[Task] <short task name>"
+labels: ["task"]
+assignees: []
+---
+
+## Task Name
+
+<!-- A short, clear name for this task. Example: Clinic Finder map integration -->
+
+## Summary
+
+<!-- One or two sentences describing what needs to be done and why. -->
+
+## Contribution Area
+
+<!-- Select the area this task belongs to. Delete the rest. -->
+
+- [ ] Frontend (HTML / CSS / JavaScript)
+- [ ] Backend (Node.js / Express / Supabase)
+- [ ] UI / UX Design
+- [ ] Content / Clinical
+- [ ] Docs
+- [ ] Admin / Moderation
+
+## Related PRD Section
+
+<!-- Reference the relevant PRD or TRD section so reviewers have context. -->
+
+## Description / Requirements
+
+<!-- Describe the work in detail. List the specific requirements this task must meet. -->
+
+-
+-
+-
+
+## Acceptance Criteria
+
+<!-- The conditions that must be true for this task to be considered done. -->
+
+- [ ]
+- [ ]
+- [ ]
+
+## Branch
+
+<!-- Branch this work from `dev`, following the naming convention. -->
+<!-- feature/... | fix/... | docs/... | refactor/... | design/... -->
+
+Branch name: `feature/<name>`
+
+## Linked Pull Request
+
+<!--
+Link the PR once opened. To auto-close this issue on merge, put a closing
+keyword in the PR description, e.g. "Closes #<this-issue-number>".
+-->
+
+PR: #
+
+## Checklist
+
+- [ ] Branched from `dev` and PR targets `dev`
+- [ ] No console errors
+- [ ] Responsive layout works at 360px width
+- [ ] Accessibility basics covered (WCAG 2.1 AA)
+- [ ] No broken links
+- [ ] Respects privacy, safety, and non-stigmatizing language
+
+## Additional Context
+
+<!-- Screenshots, mockups, references, or anything else useful. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,65 @@
+<!--
+Thank you for contributing to Bloom After.
+Please read CONTRIBUTING.md before submitting. All PRs must target the `dev` branch.
+-->
+
+## Task Name
+
+<!-- A short, clear name for this change. Should match the linked issue. -->
+
+## Summary
+
+<!-- Clearly describe the feature or fix and why it is needed. -->
+
+## Type of Change
+
+- [ ] Feature
+- [ ] Fix
+- [ ] Docs
+- [ ] Refactor
+- [ ] Design
+
+## Contribution Area
+
+- [ ] Frontend (HTML / CSS / JavaScript)
+- [ ] Backend (Node.js / Express / Supabase)
+- [ ] UI / UX Design
+- [ ] Content / Clinical
+- [ ] Admin / Moderation
+
+## Related PRD Section
+
+<!-- Reference the relevant PRD or TRD section. -->
+
+## Linked Issue
+
+<!--
+Use a closing keyword so the issue auto-closes on merge.
+Example: Closes #12
+-->
+
+Closes #
+
+## Changes
+
+<!-- List the main changes in this PR. Keep the PR focused; no unrelated changes. -->
+
+-
+-
+-
+
+## Screenshots
+
+<!-- Required for UI changes. Before / after if applicable. -->
+
+## Checklist
+
+- [ ] Branched from `dev` and this PR targets `dev`
+- [ ] Branch name follows the convention (feature/ | fix/ | docs/ | refactor/ | design/)
+- [ ] No console errors
+- [ ] Responsive layout works at 360px width
+- [ ] Accessibility basics covered (WCAG 2.1 AA)
+- [ ] No broken links
+- [ ] PR is focused with no unrelated changes
+- [ ] Respects privacy, safety, and non-stigmatizing language
+- [ ] Medical content is evidence-based and includes source references (if applicable)

--- a/migration/.gitignore
+++ b/migration/.gitignore
@@ -1,0 +1,41 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/versions
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# env files (can opt-in for committing if needed)
+.env*
+
+# vercel
+.vercel
+
+# typescript
+*.tsbuildinfo
+next-env.d.ts


### PR DESCRIPTION
Add GitHub issue templates (task/feature and bug report) and a pull request template to standardize contributions. Templates mirror project conventions from CONTRIBUTING.md: PRs target `dev`, branch naming rules, 360px responsive and WCAG 2.1 AA checks, and ethical/clinical content requirements. Issue and PR templates include a task name and linked-PR field so issues auto-close on merge via closing keywords.