### PR TITLE
feat: build admin dashboard page with live backend stats and moderation queue

### DIFF
--- a/migration/app/(admin)/admin/(dashboard)/dashboard/page.tsx
+++ b/migration/app/(admin)/admin/(dashboard)/dashboard/page.tsx
@@ -1,0 +1,363 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { getAdminUser } from "@/lib/admin-session";
+import {
+  AdminAuthError,
+  fetchAdminModerationQueue,
+  fetchAdminStats,
+} from "@/lib/api/admin-dashboard-api";
+import { AdminQueueItem, AdminStats } from "@/types/admin-dashboard";
+
+interface StatCard {
+  id: string;
+  label: string;
+  value: string;
+  meta: string;
+}
+
+const fmtNumber = (value: number): string =>
+  new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 }).format(value || 0);
+
+const fmtDate = (iso: string | null): string => {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+};
+
+const buildStatCards = (stats: AdminStats | null): StatCard[] => {
+  const resources = stats?.resources ?? { total: 0, published: 0, drafts: 0 };
+  const stories = stats?.stories ?? { total: 0, pending: 0, approved: 0 };
+  const ngos = stats?.ngos ?? { total: 0, pending: 0, approved: 0 };
+
+  return [
+    {
+      id: "total-resources-card",
+      label: "Total Resources",
+      value: fmtNumber(resources.total),
+      meta: "All content across every type",
+    },
+    {
+      id: "published-resources-card",
+      label: "Published",
+      value: fmtNumber(resources.published),
+      meta: "Live on Bloom After",
+    },
+    {
+      id: "pending-stories-card",
+      label: "Pending Stories",
+      value: fmtNumber(stories.pending),
+      meta: "Story submissions awaiting review",
+    },
+    {
+      id: "pending-ngos-card",
+      label: "Pending NGOs",
+      value: fmtNumber(ngos.pending),
+      meta: "NGO submissions awaiting review",
+    },
+  ];
+};
+
+const TYPE_LABEL: Record<AdminQueueItem["type"], string> = {
+  story: "Story",
+  ngo: "NGO",
+  suggestion: "Suggestion",
+};
+
+const TYPE_BADGE_CLASS: Record<AdminQueueItem["type"], string> = {
+  story: "mod-type-story",
+  ngo: "mod-type-ngo",
+  suggestion: "mod-type-suggestion",
+};
+
+const ROLES = [
+  {
+    id: "super-admin-role",
+    name: "Super Admin",
+    desc: "Manage approvals, users, publishing rules, and analytics visibility.",
+  },
+  {
+    id: "content-editor-role",
+    name: "Content Editor",
+    desc: "Create, edit, archive, and prepare resource hub and directory content.",
+  },
+  {
+    id: "moderator-role",
+    name: "Moderator",
+    desc: "Review stories, submissions, flagged content, and podcast suggestions.",
+  },
+];
+
+export default function AdminDashboardPage() {
+  const router = useRouter();
+  const [adminName, setAdminName] = useState("Admin");
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [queue, setQueue] = useState<AdminQueueItem[]>([]);
+  const [statsLoading, setStatsLoading] = useState(true);
+  const [queueLoading, setQueueLoading] = useState(true);
+
+  useEffect(() => {
+    const user = getAdminUser();
+    if (user?.name) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing client-only sessionStorage into state after mount
+      setAdminName(user.name);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const handleAuthError = (error: unknown) => {
+      if (error instanceof AdminAuthError) {
+        router.replace("/admin/login");
+        return true;
+      }
+      return false;
+    };
+
+    fetchAdminStats()
+      .then((data) => {
+        if (!cancelled) setStats(data);
+      })
+      .catch(handleAuthError)
+      .finally(() => {
+        if (!cancelled) setStatsLoading(false);
+      });
+
+    fetchAdminModerationQueue()
+      .then((items) => {
+        if (!cancelled) setQueue(items);
+      })
+      .catch(handleAuthError)
+      .finally(() => {
+        if (!cancelled) setQueueLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  const statCards = buildStatCards(stats);
+  const totalPending = queue.length;
+
+  return (
+    <main className="dashboard-content" id="dashboard-content">
+      <section id="welcome-section">
+        <div className="welcome-card">
+          <div className="welcome-text">
+            <p className="welcome-eyebrow">Admin Dashboard</p>
+            <h3 className="welcome-title">Welcome, {adminName}</h3>
+            <p className="welcome-subtitle">
+              Manage content, reviews, and approvals from one place.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section id="overview-section" aria-busy={statsLoading}>
+        <div className="dashboard-section-header">
+          <span className="section-icon material-symbols-outlined">insights</span>
+          <h2 className="dashboard-section-title">Overview</h2>
+        </div>
+        <div className="stats-grid">
+          {statsLoading
+            ? Array.from({ length: 4 }).map((_, i) => (
+                <div className="stat-card skeleton" aria-hidden="true" key={i}>
+                  <div className="skeleton-line skeleton-label"></div>
+                  <div className="skeleton-line skeleton-value"></div>
+                  <div className="skeleton-line skeleton-meta"></div>
+                </div>
+              ))
+            : statCards.map((card) => (
+                <div className="stat-card" id={card.id} key={card.id}>
+                  <div className="stat-label">{card.label}</div>
+                  <div className={`stat-value${card.value.length > 10 ? " long" : ""}`}>
+                    {card.value}
+                  </div>
+                  <div className="stat-meta muted">{card.meta}</div>
+                </div>
+              ))}
+        </div>
+      </section>
+
+      <div className="queues-content-grid">
+        <div className="queues-left-col" id="queues-section">
+          <div className="dash-stories-widget" id="moderation-queue-widget">
+            <div className="dash-stories-widget-header">
+              <h3 className="dash-stories-widget-title">
+                Moderation Queue{" "}
+                {totalPending > 0 && (
+                  <span className="dash-stories-badge">{totalPending} pending</span>
+                )}
+              </h3>
+              <Link href="/admin/moderation/stories" className="dash-stories-view-all">
+                View All →
+              </Link>
+            </div>
+            <div className="stories-table-wrap">
+              <table className="stories-table" aria-label="Recent moderation submissions">
+                <thead>
+                  <tr className="stories-thead-row">
+                    <th className="stories-th">Type</th>
+                    <th className="stories-th">Title / Excerpt</th>
+                    <th className="stories-th">Status</th>
+                    <th className="stories-th stories-th-right">Action</th>
+                  </tr>
+                </thead>
+                <tbody aria-live="polite">
+                  {queueLoading ? (
+                    Array.from({ length: 5 }).map((_, i) => (
+                      <tr className="stories-table-row" aria-hidden="true" key={i}>
+                        <td className="stories-td">
+                          <div
+                            className="skeleton-line"
+                            style={{ width: 56, borderRadius: 999 }}
+                          ></div>
+                        </td>
+                        <td className="stories-td">
+                          <div
+                            className="skeleton-line"
+                            style={{ width: 160, marginBottom: 5 }}
+                          ></div>
+                          <div className="skeleton-line" style={{ width: 72 }}></div>
+                        </td>
+                        <td className="stories-td">
+                          <div
+                            className="skeleton-line"
+                            style={{ width: 60, borderRadius: 999 }}
+                          ></div>
+                        </td>
+                        <td className="stories-td"></td>
+                      </tr>
+                    ))
+                  ) : queue.length === 0 ? (
+                    <tr>
+                      <td colSpan={4} className="stories-table-empty">
+                        No pending submissions. You&apos;re all caught up!
+                      </td>
+                    </tr>
+                  ) : (
+                    queue.slice(0, 4).map((item) => (
+                      <tr className="stories-table-row" key={`${item.type}-${item.id}`}>
+                        <td className="stories-td">
+                          <span className={`mod-type-badge ${TYPE_BADGE_CLASS[item.type]}`}>
+                            {TYPE_LABEL[item.type]}
+                          </span>
+                        </td>
+                        <td className="stories-td stories-td-title">
+                          <span className="mod-queue-title">{item.title}</span>
+                          {item.submittedAt && (
+                            <span className="mod-queue-date">{fmtDate(item.submittedAt)}</span>
+                          )}
+                        </td>
+                        <td className="stories-td">
+                          <span className={`mod-status-badge mod-status-${item.status}`}>
+                            {item.status}
+                          </span>
+                        </td>
+                        <td className="stories-td stories-td-action">
+                          <Link href={item.reviewHref} className="stories-review-btn">
+                            Review
+                          </Link>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+            <div className="mod-queue-footer">
+              <span className="mod-queue-footer-label">Jump to:</span>
+              <Link href="/admin/moderation/stories" className="mod-queue-type-link">
+                Stories
+              </Link>
+              <Link href="/admin/moderation?type=ngo" className="mod-queue-type-link">
+                NGOs
+              </Link>
+              <Link href="/admin/moderation?type=media" className="mod-queue-type-link">
+                Suggestions
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <section id="content-section">
+          <div className="dashboard-section-header">
+            <span className="section-icon material-symbols-outlined">article</span>
+            <h2 className="dashboard-section-title">Content Management</h2>
+          </div>
+          <div className="action-stack">
+            <Link
+              href="/admin/content-manager/editor?type=resource"
+              className="action-row"
+              id="create-resource-action"
+            >
+              <span className="action-row-icon material-symbols-outlined">post_add</span>
+              <span className="action-row-label">Create Resource Article</span>
+              <span className="action-row-chevron material-symbols-outlined">chevron_right</span>
+            </Link>
+
+            <Link
+              href="/admin/content-manager"
+              className="action-row"
+              id="update-directory-action"
+            >
+              <span className="action-row-icon material-symbols-outlined">folder_open</span>
+              <span className="action-row-label">Manage All Content</span>
+              <span className="action-row-chevron material-symbols-outlined">chevron_right</span>
+            </Link>
+
+            <Link
+              href="/admin/content-manager?filter=published"
+              className="action-row"
+              id="featured-content-action"
+            >
+              <span className="action-row-icon material-symbols-outlined">star</span>
+              <span className="action-row-label">Update Featured Content</span>
+              <span className="action-row-chevron material-symbols-outlined">chevron_right</span>
+            </Link>
+
+            <Link
+              href="/admin/content-manager?filter=ngo"
+              className="action-row"
+              id="ngo-directory-action"
+            >
+              <span className="action-row-icon material-symbols-outlined">diversity_3</span>
+              <span className="action-row-label">NGO Directory</span>
+              <span className="action-row-chevron material-symbols-outlined">chevron_right</span>
+            </Link>
+
+            <Link
+              href="/admin/content-manager?filter=clinic"
+              className="action-row"
+              id="clinic-directory-action"
+            >
+              <span className="action-row-icon material-symbols-outlined">local_hospital</span>
+              <span className="action-row-label">Clinic Directory</span>
+              <span className="action-row-chevron material-symbols-outlined">chevron_right</span>
+            </Link>
+          </div>
+        </section>
+      </div>
+
+      <section id="roles-section">
+        <div className="dashboard-section-header">
+          <span className="section-icon material-symbols-outlined">groups</span>
+          <h2 className="dashboard-section-title">User Access</h2>
+        </div>
+        <div className="role-grid">
+          {ROLES.map((role) => (
+            <div className="role-card" id={role.id} key={role.id}>
+              <div className="role-name">{role.name}</div>
+              <div className="role-desc">{role.desc}</div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/migration/app/(admin)/admin/(dashboard)/layout.tsx
+++ b/migration/app/(admin)/admin/(dashboard)/layout.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 import AdminTopNav from "@/components/admin/AdminTopNav";
+import { fetchAdminPendingCount } from "@/lib/api/admin-dashboard-api";
 
 export default function AdminDashboardLayout({
   children,
@@ -10,10 +11,25 @@ export default function AdminDashboardLayout({
   children: React.ReactNode;
 }>) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [totalPending, setTotalPending] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAdminPendingCount()
+      .then((count) => {
+        if (!cancelled) setTotalPending(count);
+      })
+      .catch(() => {
+        // Sidebar badge is non-critical — leave it at 0 on failure.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return (
     <div className="admin-layout">
-      <AdminSidebar isOpen={isSidebarOpen} setIsOpen={setIsSidebarOpen} />
+      <AdminSidebar isOpen={isSidebarOpen} setIsOpen={setIsSidebarOpen} totalPending={totalPending} />
       
       {/* Mobile overlay */}
       <div 

--- a/migration/components/admin/AdminSidebar.tsx
+++ b/migration/components/admin/AdminSidebar.tsx
@@ -9,11 +9,13 @@ import { getAdminUser, logoutAdmin } from "@/lib/admin-session";
 interface AdminSidebarProps {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
+  totalPending?: number;
 }
 
 interface NavChild {
   label: string;
   href: string;
+  badge?: boolean;
 }
 
 interface NavItem {
@@ -21,6 +23,7 @@ interface NavItem {
   icon: string;
   label: string;
   href?: string;
+  badge?: boolean;
   children?: NavChild[];
 }
 
@@ -39,8 +42,9 @@ const navGroups: NavGroup[] = [
         id: "moderation",
         icon: "gavel",
         label: "Moderation",
+        badge: true,
         children: [
-          { label: "Stories", href: "/admin/moderation/stories" },
+          { label: "Stories", href: "/admin/moderation/stories", badge: true },
           { label: "Clinics", href: "/admin/moderation?type=clinic" },
           { label: "Specialists Onboarding", href: "/admin/moderation?type=specialist" },
           { label: "Media Suggestions", href: "/admin/moderation?type=media" },
@@ -53,12 +57,12 @@ const navGroups: NavGroup[] = [
   {
     label: "SYSTEM",
     items: [
-      { id: "settings", icon: "settings", label: "General Settings", href: "/admin/dashboard/settings" },
+      { id: "settings", icon: "settings", label: "General Settings", href: "/admin/settings" },
     ],
   },
 ];
 
-export default function AdminSidebar({ isOpen, setIsOpen }: AdminSidebarProps) {
+export default function AdminSidebar({ isOpen, setIsOpen, totalPending = 0 }: AdminSidebarProps) {
   const pathname = usePathname();
   const router = useRouter();
   const [role, setRole] = useState("Admin");
@@ -127,6 +131,11 @@ export default function AdminSidebar({ isOpen, setIsOpen }: AdminSidebarProps) {
                       >
                         <span className="sidebar-nav-icon material-symbols-outlined">{item.icon}</span>
                         <span>{item.label}</span>
+                        {item.badge && totalPending > 0 && (
+                          <span className="sidebar-badge" aria-label={`${totalPending} pending`}>
+                            {totalPending}
+                          </span>
+                        )}
                         <span className="sidebar-nav-chevron material-symbols-outlined" aria-hidden="true">
                           expand_more
                         </span>
@@ -148,6 +157,11 @@ export default function AdminSidebar({ isOpen, setIsOpen }: AdminSidebarProps) {
                               >
                                 <span className="sidebar-subnav-dot" aria-hidden="true"></span>
                                 <span>{child.label}</span>
+                                {child.badge && totalPending > 0 && (
+                                  <span className="sidebar-badge" aria-label={`${totalPending} pending`}>
+                                    {totalPending}
+                                  </span>
+                                )}
                               </Link>
                             </li>
                           );

--- a/migration/lib/api/admin-dashboard-api.ts
+++ b/migration/lib/api/admin-dashboard-api.ts
@@ -1,0 +1,160 @@
+import api, { ApiError } from "../api";
+import {
+  AdminStats,
+  AdminStatsApiResponse,
+  AdminStoriesListApiResponse,
+  AdminNgosListApiResponse,
+  AdminSuggestionsListApiResponse,
+  AdminQueueItem,
+  AdminQueueItemType,
+} from "@/types/admin-dashboard";
+
+export class AdminAuthError extends Error {
+  constructor() {
+    super("Admin session expired or unauthorized.");
+    this.name = "AdminAuthError";
+  }
+}
+
+const isAuthError = (error: unknown): boolean =>
+  error instanceof ApiError && (error.status === 401 || error.status === 403);
+
+export async function fetchAdminStats(): Promise<AdminStats> {
+  try {
+    const res = await api.get<AdminStatsApiResponse>("/api/v1/admin/stats");
+    return res.data;
+  } catch (error) {
+    if (isAuthError(error)) throw new AdminAuthError();
+    throw error;
+  }
+}
+
+const stripHtml = (value: string): string => value.replace(/<[^>]+>/g, " ").trim();
+
+const REVIEW_HREF: Record<AdminQueueItemType, (id: string) => string> = {
+  story: (id) => `/admin/moderation/stories?id=${encodeURIComponent(id)}`,
+  ngo: (id) => `/admin/moderation?type=ngo&id=${encodeURIComponent(id)}`,
+  suggestion: (id) => `/admin/moderation?type=media&id=${encodeURIComponent(id)}`,
+};
+
+const normalizeQueueItem = (
+  item: Record<string, unknown>,
+  type: AdminQueueItemType
+): AdminQueueItem => {
+  const id = String(item._id || item.id || "");
+  const content = typeof item.content === "string" ? item.content : "";
+  const story = typeof item.story === "string" ? item.story : "";
+  const storyText = typeof item.story_text === "string" ? item.story_text : "";
+
+  const title =
+    (typeof item.title === "string" && item.title) ||
+    (typeof item.name === "string" && item.name) ||
+    (content && content.slice(0, 80)) ||
+    (story && stripHtml(story).slice(0, 80)) ||
+    (storyText && storyText.slice(0, 80)) ||
+    "Untitled";
+
+  const contact = (item.contact as { email?: string } | undefined) || undefined;
+  const submittedBy =
+    (typeof item.submittedBy === "string" && item.submittedBy) ||
+    (typeof item.email === "string" && item.email) ||
+    contact?.email ||
+    (item.privacy === "named" && typeof item.name === "string" ? item.name : null) ||
+    (type === "story" ? "Anonymous" : null);
+
+  return {
+    id,
+    type,
+    title: title || "Untitled",
+    submittedBy: submittedBy || null,
+    submittedAt:
+      (typeof item.submittedAt === "string" && item.submittedAt) ||
+      (typeof item.createdAt === "string" && item.createdAt) ||
+      null,
+    status: (typeof item.status === "string" && item.status) || "pending",
+    reviewHref: REVIEW_HREF[type](id),
+  };
+};
+
+const rejectsWithAuthError = (results: PromiseSettledResult<unknown>[]): boolean =>
+  results.some((r) => r.status === "rejected" && isAuthError(r.reason));
+
+/**
+ * Pulls the unified "needs review" queue. Only stories, NGOs, and suggestions
+ * have a pending-approval workflow on the backend — clinics are admin-authored
+ * (draft/published/archived) so they're excluded here, see types/admin-dashboard.ts.
+ */
+export async function fetchAdminModerationQueue(): Promise<AdminQueueItem[]> {
+  const [storiesRes, ngosRes, suggestionsRes] = await Promise.allSettled([
+    api.get<AdminStoriesListApiResponse>("/api/v1/admin/stories", {
+      query: { status: "pending" },
+    }),
+    api.get<AdminNgosListApiResponse>("/api/v1/admin/ngos", {
+      query: { status: "pending", limit: 50 },
+    }),
+    api.get<AdminSuggestionsListApiResponse>("/api/v1/admin/suggestions", {
+      query: { status: "pending", limit: 50 },
+    }),
+  ]);
+
+  if (rejectsWithAuthError([storiesRes, ngosRes, suggestionsRes])) {
+    throw new AdminAuthError();
+  }
+
+  const items: AdminQueueItem[] = [];
+
+  if (storiesRes.status === "fulfilled") {
+    (storiesRes.value.data?.stories || []).forEach((item) =>
+      items.push(normalizeQueueItem(item, "story"))
+    );
+  }
+  if (ngosRes.status === "fulfilled") {
+    (ngosRes.value.data?.ngos || []).forEach((item) =>
+      items.push(normalizeQueueItem(item, "ngo"))
+    );
+  }
+  if (suggestionsRes.status === "fulfilled") {
+    (suggestionsRes.value.data?.suggestions || []).forEach((item) =>
+      items.push(normalizeQueueItem(item, "suggestion"))
+    );
+  }
+
+  return items.sort(
+    (a, b) => new Date(b.submittedAt || 0).getTime() - new Date(a.submittedAt || 0).getTime()
+  );
+}
+
+/**
+ * Lightweight pending count for the sidebar badge, shown on every admin page.
+ * Filters server-side by status so it doesn't pull full submission payloads.
+ */
+export async function fetchAdminPendingCount(): Promise<number> {
+  const [storiesRes, ngosRes, suggestionsRes] = await Promise.allSettled([
+    api.get<AdminStoriesListApiResponse>("/api/v1/admin/stories", {
+      query: { status: "pending" },
+    }),
+    api.get<{ pagination?: { totalNgos?: number } }>("/api/v1/admin/ngos", {
+      query: { status: "pending", limit: 1 },
+    }),
+    api.get<{ pagination?: { totalSuggestions?: number } }>("/api/v1/admin/suggestions", {
+      query: { status: "pending", limit: 1 },
+    }),
+  ]);
+
+  if (rejectsWithAuthError([storiesRes, ngosRes, suggestionsRes])) {
+    throw new AdminAuthError();
+  }
+
+  let total = 0;
+  if (storiesRes.status === "fulfilled") {
+    total += storiesRes.value.data?.stories?.length || 0;
+  }
+  if (ngosRes.status === "fulfilled") {
+    total += ngosRes.value.pagination?.totalNgos || 0;
+  }
+  if (suggestionsRes.status === "fulfilled") {
+    total += suggestionsRes.value.pagination?.totalSuggestions || 0;
+  }
+
+  return total;
+}

--- a/migration/styles/admin-dashboard.css
+++ b/migration/styles/admin-dashboard.css
@@ -342,6 +342,7 @@
 /* Topbar */
 .admin-topbar {
   display: flex;
+  flex-direction: row;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-4);

--- a/migration/types/admin-dashboard.ts
+++ b/migration/types/admin-dashboard.ts
@@ -1,0 +1,57 @@
+// Mirrors server/controllers/adminStatsController.js response shape.
+export interface AdminStats {
+  resources: {
+    total: number;
+    published: number;
+    drafts: number;
+  };
+  stories: {
+    total: number;
+    pending: number;
+    approved: number;
+  };
+  ngos: {
+    total: number;
+    pending: number;
+    approved: number;
+  };
+}
+
+export interface AdminStatsApiResponse {
+  status: string;
+  data: AdminStats;
+}
+
+// Raw admin list endpoints — each wraps its array under a type-named key.
+// See server/controllers/{stories,ngos,clinics,suggestions}Controller.js getAdmin* handlers.
+export interface AdminStoriesListApiResponse {
+  status: string;
+  data: { stories: Array<Record<string, unknown>> };
+}
+
+export interface AdminNgosListApiResponse {
+  status: string;
+  data: { ngos: Array<Record<string, unknown>> };
+}
+
+export interface AdminSuggestionsListApiResponse {
+  status: string;
+  data: { suggestions: Array<Record<string, unknown>> };
+}
+
+// Clinics are admin-authored (draft/published/archived) rather than public
+// submissions awaiting moderation — server/models/clinic.js has no "pending"
+// status, so clinics are intentionally excluded from the moderation queue.
+export type AdminQueueItemType = "story" | "ngo" | "suggestion";
+
+// Unified shape the dashboard's moderation queue renders, regardless of
+// which submission type it came from.
+export interface AdminQueueItem {
+  id: string;
+  type: AdminQueueItemType;
+  title: string;
+  submittedBy: string | null;
+  submittedAt: string | null;
+  status: string;
+  reviewHref: string;
+}


### PR DESCRIPTION
## Task Name

Admin Dashboard Backend Integration

## Summary

Ports the admin dashboard from the legacy client to the migration app, replaces static placeholders with live backend data, adds typed dashboard APIs and models, implements moderation queue support using actual backend entities, fixes admin navigation issues, adds pending-count badges, and resolves admin topbar layout regressions.

## Linked Issue

Closes #158

## Checklist

- [x] Targets `migration` and branch follows naming convention
- [x] No console errors and works at 360px width
- [ ] Screenshots added (for UI changes)
- [x] Focused PR, non-stigmatizing language