### PR TITLE
Feat/migrate content manager and editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,10 @@ Bloom After follows a layered architecture.
 
 | Layer | Responsibility |
 |------|---------------|
-| Frontend | HTML, CSS, and modular JavaScript UI |
+| Frontend | Next.js (App Router) + React + TypeScript UI |
 | Backend API | Node.js + Express API handling business logic |
-| Database | PostgreSQL via Supabase |
-| CMS | Strapi for editorial content management |
-| File Storage | Cloudinary or Supabase Storage |
+| Database | MongoDB via Mongoose |
+| File Storage | Cloudinary |
 
 **Flow**
 
@@ -68,6 +67,33 @@ The frontend is hosted on **Netlify**, while the backend API runs on **Render or
 ---
 
 ## Changelog
+
+### Frontend Migration to Next.js — ongoing, started 2026
+
+**Changed by:** The Bloom After team
+
+**What Changed:**
+The frontend is being rebuilt page by page in `/migration` using Next.js
+(App Router), React, and TypeScript, replacing the original HTML/CSS/vanilla
+JavaScript frontend in `/client`. The admin dashboard and content management
+screens (content list + content editor) have been ported so far, alongside
+several public-facing pages. `/client` remains in the repo as a working
+reference until the migration is complete.
+
+**Why It Changed:**
+The vanilla JS frontend had grown hard to maintain as a single shared
+component/data layer across many hand-wired pages. Next.js gives the project
+typed components, a shared layout system, and a clearer separation between
+API clients (`lib/api/`), framework-agnostic helpers (`lib/`), and types
+(`types/`).
+
+**Impact on Other Components:**
+Root-level `npm run dev` / `npm run build` now point at `/migration` by
+default; the legacy equivalents are available as `npm run dev:legacy` /
+`npm run build:legacy`. No backend changes were required — the new frontend
+talks to the same Express API in `/server`.
+
+---
 
 ### PRD Update — 10th March, 2026
 
@@ -91,22 +117,26 @@ The Resource Hub now has a dedicated media section to make up for removing the m
 ## Technology Stack
 
 ### Frontend
-- HTML
+- [Next.js](https://nextjs.org) (App Router)
+- React + TypeScript
 - CSS (mobile-first responsive design)
-- Vanilla JavaScript
+
+> The original frontend (`/client`) was plain HTML, CSS, and vanilla JavaScript.
+> It's kept for reference during the migration but is no longer where new
+> frontend work happens — see [Repository Structure](#repository-structure).
 
 ### Backend
 - Node.js
 - Express.js
 
 ### Database
-- Supabase (PostgreSQL)
+- MongoDB (via Mongoose)
 
 ### Additional Services
-- Strapi CMS
 - Cloudinary (media storage)
 - Leaflet.js + OpenStreetMap (maps)
 - Browser Geolocation API
+- Resend (transactional email — admin invites, moderation notifications)
 
 ---
 
@@ -114,7 +144,8 @@ The Resource Hub now has a dedicated media section to make up for removing the m
 
 ```
 /bloom-after
-  /client          # frontend
+  /migration       # frontend (Next.js, active development)
+  /client          # legacy frontend (HTML/CSS/vanilla JS, kept for reference)
   /server          # backend API
   /scripts         # seed scripts and helpers
   README.md
@@ -122,6 +153,17 @@ The Resource Hub now has a dedicated media section to make up for removing the m
 ```
 
 ### Frontend Structure
+
+```
+/migration
+  /app             # routes (App Router) — public + (admin) route groups
+  /components      # shared and feature React components
+  /lib             # API clients and framework-agnostic helpers
+  /types           # shared TypeScript types
+  /styles          # CSS, ported 1:1 from /client where applicable
+```
+
+The legacy `/client` frontend follows its own structure:
 
 ```
 /client
@@ -178,36 +220,52 @@ Navigate into the project:
 cd bloom-after
 ```
 
-Install backend dependencies:
+Install dependencies for the frontend and backend:
 
 ```bash
-cd server
-npm install
+cd migration && npm install && cd ..
+cd server && npm install && cd ..
 ```
 
-Run the development server:
+Run the backend API:
+
+```bash
+npm run dev:server
+```
+
+Run the frontend (Next.js, from the repo root):
 
 ```bash
 npm run dev
 ```
 
+This opens the app at [http://localhost:3000](http://localhost:3000).
+
+The legacy frontend under `/client` is still runnable via `npm run dev:legacy`
+/ `npm run build:legacy` while the migration to Next.js is completed page by page.
+
 ### Environment Variables
 
-Create a .env file using .env.example as a template.
-
-Required variables include:
+Create a `.env` file inside `/server` with the variables it actually reads:
 
 ```
-SUPABASE_URL=
-SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_KEY=
+MONGO_URI=
 JWT_SECRET=
 CLOUDINARY_CLOUD_NAME=
 CLOUDINARY_API_KEY=
 CLOUDINARY_API_SECRET=
-STRAPI_URL=
-PORT=
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=
+APP_BASE_URL=
+CORS_ALLOWED_ORIGINS=
+SUPPORT_EMAIL=
 ```
+
+`MONGO_URI`, `JWT_SECRET`, and the `CLOUDINARY_*` keys are required for the
+API and uploads to work; the rest have sane defaults and are only needed to
+override behavior (allowed CORS origins, the base URL used in moderation
+emails, etc.) — see `server/server.js` and `server/utils/` for exactly how
+each one is used.
 
 ## Contributing
 

--- a/migration/README.md
+++ b/migration/README.md
@@ -1,24 +1,32 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+This is the Bloom After frontend — a [Next.js](https://nextjs.org) (App Router) rewrite of the original `/client` (HTML/CSS/vanilla JS) app. See the root [README.md](../README.md) for the project overview and the "Frontend Migration to Next.js" changelog entry for context.
 
 ## Getting Started
 
-First, run the development server:
+From the repo root:
 
 ```bash
+npm install --prefix migration
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Or from this directory directly:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+npm install
+npm run dev
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. The backend API (in `/server`) must be running separately — see the root README for setup.
+
+## Structure
+
+- `app/` — routes (App Router). Public pages and the `(admin)` route group for the admin dashboard, content manager, and moderation tools.
+- `components/` — shared and feature-specific React components.
+- `lib/` — API clients (`lib/api/`) and framework-agnostic helpers.
+- `types/` — shared TypeScript types, generally mirroring backend response shapes.
+- `styles/` — CSS, ported from `/client` where a page has an equivalent there.
+
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to load Geist and Inter.
 
 ## Learn More
 
@@ -26,11 +34,3 @@ To learn more about Next.js, take a look at the following resources:
 
 - [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.

--- a/migration/app/(admin)/admin/(dashboard)/content-manager/editor/page.tsx
+++ b/migration/app/(admin)/admin/(dashboard)/content-manager/editor/page.tsx
@@ -1,0 +1,620 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { AlertCircle, ArrowLeft, Eye, Upload, X } from "lucide-react";
+import {
+  FIELD_DEFS,
+  getDestination,
+  getVisibleFields,
+  isFieldRequired,
+  toApiPayload,
+} from "@/lib/content-management";
+import {
+  fetchContentEntry,
+  saveContentEntry,
+  uploadContentImage,
+} from "@/lib/api/content-management-api";
+import { AdminAuthError } from "@/lib/api/admin-dashboard-api";
+import { ContentDestination, ContentFormData, ContentStatus, FieldDef } from "@/types/content-management";
+
+type Feedback = { message: string; type: "success" | "error" } | null;
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result || ""));
+    reader.onerror = () => resolve("");
+    reader.readAsDataURL(file);
+  });
+}
+
+// ── Image field — URL input + file upload + preview ───────────────────────────
+
+function ImageField({
+  fieldKey,
+  def,
+  value,
+  required,
+  onChange,
+  onUploadingChange,
+}: {
+  fieldKey: string;
+  def: FieldDef;
+  value: string;
+  required: boolean;
+  onChange: (value: string) => void;
+  onUploadingChange: (uploading: boolean) => void;
+}) {
+  const id = `field-${fieldKey}`;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [localPreview, setLocalPreview] = useState("");
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file || !file.type.startsWith("image/")) return;
+    const dataUrl = await readFileAsDataUrl(file);
+    if (!dataUrl) return;
+
+    setLocalPreview(dataUrl);
+    setUploading(true);
+    onUploadingChange(true);
+    try {
+      const uploadedUrl = await uploadContentImage(dataUrl);
+      onChange(uploadedUrl);
+    } catch {
+      setLocalPreview("");
+    } finally {
+      setUploading(false);
+      onUploadingChange(false);
+    }
+  };
+
+  const previewSrc = localPreview || value;
+
+  return (
+    <div className="cm-field cm-field-image">
+      <label className="cm-field-label" htmlFor={id}>
+        {def.label}
+        {required && (
+          <span className="cm-required" aria-hidden="true">
+            *
+          </span>
+        )}
+      </label>
+      <div className="cm-image-row">
+        <input
+          type="url"
+          id={id}
+          name={fieldKey}
+          className="cm-field-input"
+          value={value}
+          placeholder={def.placeholder}
+          onChange={(e) => {
+            setLocalPreview("");
+            onChange(e.target.value);
+          }}
+        />
+        <button type="button" className="btn cm-btn-upload" onClick={() => fileInputRef.current?.click()}>
+          <Upload size={14} strokeWidth={2} />
+          Upload
+        </button>
+      </div>
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept="image/*"
+        hidden
+        onChange={(e) => handleFile(e.target.files?.[0])}
+      />
+      {uploading && (
+        <div className="cm-upload-status">
+          <span className="cm-upload-spinner" aria-hidden="true"></span>
+          <span className="cm-upload-text">Uploading image…</span>
+        </div>
+      )}
+      {previewSrc && (
+        <div className="cm-image-preview-wrap">
+          {/* Admin-entered image URLs are arbitrary external hosts — next/image's domain allowlist doesn't fit here. */}
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={previewSrc} className="cm-image-preview" alt="" />
+          <button
+            type="button"
+            className="btn cm-btn-remove-image"
+            onClick={() => {
+              setLocalPreview("");
+              onChange("");
+            }}
+          >
+            Remove
+          </button>
+        </div>
+      )}
+      {def.hint && <p className="cm-field-hint">{def.hint}</p>}
+    </div>
+  );
+}
+
+// ── Generic field renderer ─────────────────────────────────────────────────────
+
+function FieldRenderer({
+  fieldKey,
+  def,
+  value,
+  required,
+  onChange,
+}: {
+  fieldKey: string;
+  def: FieldDef;
+  value: string | boolean;
+  required: boolean;
+  onChange: (value: string | boolean) => void;
+}) {
+  const id = `field-${fieldKey}`;
+  const reqMark = required && (
+    <span className="cm-required" aria-hidden="true">
+      *
+    </span>
+  );
+  const hint = def.hint && <p className="cm-field-hint">{def.hint}</p>;
+
+  if (def.type === "textarea") {
+    return (
+      <div className="cm-field">
+        <label className="cm-field-label" htmlFor={id}>
+          {def.label}
+          {reqMark}
+        </label>
+        <textarea
+          id={id}
+          name={fieldKey}
+          className="cm-field-input cm-field-textarea"
+          rows={def.rows || 4}
+          placeholder={def.placeholder}
+          value={String(value || "")}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        {hint}
+      </div>
+    );
+  }
+
+  if (def.type === "select") {
+    return (
+      <div className="cm-field">
+        <label className="cm-field-label" htmlFor={id}>
+          {def.label}
+          {reqMark}
+        </label>
+        <select
+          id={id}
+          name={fieldKey}
+          className="cm-field-input cm-field-select"
+          value={String(value || "")}
+          onChange={(e) => onChange(e.target.value)}
+        >
+          {(def.options || []).map((opt) => (
+            <option value={opt.value} key={opt.value}>
+              {opt.label}
+            </option>
+          ))}
+        </select>
+        {hint}
+      </div>
+    );
+  }
+
+  if (def.type === "checkbox") {
+    return (
+      <div className="cm-field cm-field-check">
+        <label className="cm-checkbox-label">
+          <input
+            type="checkbox"
+            id={id}
+            name={fieldKey}
+            className="cm-checkbox"
+            checked={Boolean(value)}
+            onChange={(e) => onChange(e.target.checked)}
+          />
+          <span>{def.label}</span>
+        </label>
+        {hint}
+      </div>
+    );
+  }
+
+  return (
+    <div className="cm-field">
+      <label className="cm-field-label" htmlFor={id}>
+        {def.label}
+        {reqMark}
+      </label>
+      <input
+        type={def.type}
+        id={id}
+        name={fieldKey}
+        className="cm-field-input"
+        value={String(value || "")}
+        placeholder={def.placeholder}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {hint}
+    </div>
+  );
+}
+
+// ── Preview drawer content ────────────────────────────────────────────────────
+
+function PreviewContent({ data, destColor }: { data: ContentFormData; destColor: string }) {
+  const title = String(data.title || "Untitled");
+  const body = String(data.body || data.description || data.summary || "");
+  const typeLabel = String(data.content_type || data.category || data.type);
+  const sourceUrl = data.source_url ? String(data.source_url) : "";
+  const image = data.image ? String(data.image) : "";
+  const isMedical = data.category === "medical";
+
+  return (
+    <div className="cm-preview-entry">
+      {image && (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={image} className="cm-preview-image" alt="" />
+      )}
+      <div className="cm-preview-meta">
+        <span className="cm-type-badge" style={{ "--dest-color": destColor, "--dest-bg": "var(--color-brand-50)" } as React.CSSProperties}>
+          {typeLabel}
+        </span>
+        {data.status && <span className={`cm-status-badge cm-status-${data.status}`}>{data.status}</span>}
+      </div>
+      <h2 className="cm-preview-entry-title">{title}</h2>
+      {data.summary && <p className="cm-preview-summary">{String(data.summary)}</p>}
+      {isMedical && (
+        <div className="cm-preview-disclaimer">
+          ⚕ Always speak to a qualified healthcare professional before making any changes to your treatment or
+          lifestyle.
+        </div>
+      )}
+      {body && (
+        <div className="cm-preview-body-text">
+          {body
+            .split("\n")
+            .filter(Boolean)
+            .map((p, i) => (
+              <p key={i}>{p}</p>
+            ))}
+        </div>
+      )}
+      {sourceUrl && (
+        <p className="cm-preview-source">
+          <a href={sourceUrl} target="_blank" rel="noopener noreferrer">
+            Source: {sourceUrl}
+          </a>
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Main editor ────────────────────────────────────────────────────────────────
+
+function ContentEditorContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const typeParam = (searchParams.get("type") as ContentDestination) || "resource";
+  const id = searchParams.get("id");
+  const urlTitle = searchParams.get("_title");
+
+  const dest = getDestination(typeParam);
+  const type = dest.id;
+
+  const [formData, setFormData] = useState<ContentFormData>(() => ({
+    type,
+    status: "draft",
+    featured: false,
+    ...(urlTitle ? { title: urlTitle.trim() } : {}),
+  }));
+  const [loading, setLoading] = useState(Boolean(id));
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [imageUploading, setImageUploading] = useState(false);
+  const [previewMounted, setPreviewMounted] = useState(false);
+  const [previewOpenClass, setPreviewOpenClass] = useState(false);
+
+  // NGOs have no admin "create" endpoint — only public submission + review.
+  const blockedNewNgo = type === "ngo" && !id;
+
+  useEffect(() => {
+    if (!id || blockedNewNgo) return;
+    let cancelled = false;
+    fetchContentEntry(type, id)
+      .then((data) => {
+        if (cancelled) return;
+        if (!data) {
+          setError("Entry not found or has been removed.");
+          return;
+        }
+        setFormData(data);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        if (err instanceof AdminAuthError) {
+          router.replace("/admin/login");
+          return;
+        }
+        setError("Failed to load this entry.");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [type, id, router, blockedNewNgo]);
+
+  useEffect(() => {
+    if (!isDirty) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [isDirty]);
+
+  useEffect(() => {
+    if (!feedback) return;
+    const timer = setTimeout(() => setFeedback(null), 5000);
+    return () => clearTimeout(timer);
+  }, [feedback]);
+
+  const setField = (key: string, value: string | boolean) => {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+    setIsDirty(true);
+  };
+
+  const openPreview = () => setPreviewMounted(true);
+  const closePreview = () => {
+    setPreviewOpenClass(false);
+    setTimeout(() => setPreviewMounted(false), 300);
+  };
+
+  useEffect(() => {
+    if (!previewMounted) return;
+    const raf = requestAnimationFrame(() => setPreviewOpenClass(true));
+    return () => cancelAnimationFrame(raf);
+  }, [previewMounted]);
+
+  const visibleFields = getVisibleFields(type, dest.fields, formData);
+
+  const handleSave = async () => {
+    if (imageUploading) {
+      setFeedback({ message: "Please wait for image upload to finish.", type: "error" });
+      return;
+    }
+
+    const missing = visibleFields.filter((key) => isFieldRequired(type, key, formData) && !formData[key]);
+    if (missing.length) {
+      const labels = missing.map((k) => FIELD_DEFS[k]?.label || k).join(", ");
+      setFeedback({ message: `Please fill in required fields: ${labels}`, type: "error" });
+      document.getElementById(`field-${missing[0]}`)?.focus();
+      return;
+    }
+
+    setSaving(true);
+    setFeedback(null);
+    try {
+      const payload = toApiPayload(type, formData);
+      const result = await saveContentEntry(type, id, payload);
+      setIsDirty(false);
+
+      if (!id) {
+        router.replace(`/admin/content-manager/editor?type=${type}&id=${result.id}`);
+        return;
+      }
+
+      setFormData(result.formData);
+      setFeedback({ message: "Saved successfully.", type: "success" });
+    } catch (err) {
+      if (err instanceof AdminAuthError) {
+        router.replace("/admin/login");
+        return;
+      }
+      setFeedback({ message: "Failed to save. Please try again.", type: "error" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <main className="dashboard-content" id="main-content">
+      <div className="cm-editor-nav">
+        <Link href={dest.backUrl} className="mod-back-link">
+          <ArrowLeft size={16} />
+          Content Management
+        </Link>
+        <span className="cm-breadcrumb-sep" aria-hidden="true">
+          /
+        </span>
+        <span className="cm-breadcrumb-current">
+          {id ? `Edit ${dest.label}` : `New ${dest.label}`}
+        </span>
+      </div>
+
+      {blockedNewNgo ? (
+        <div className="mod-error-state" role="alert">
+          <AlertCircle size={48} color="var(--color-warning)" style={{ margin: "0 auto 16px" }} />
+          <h2>NGOs can&apos;t be created here</h2>
+          <p className="mod-error-message">
+            NGOs are added through public submissions. You can edit and review existing entries from the
+            moderation queue or the content table.
+          </p>
+          <Link href={dest.backUrl} className="btn btn-primary" style={{ marginTop: 24, display: "inline-block" }}>
+            Back to Content Management
+          </Link>
+        </div>
+      ) : loading ? (
+        <div className="cm-editor-layout">
+          <div className="cm-editor-main">
+            <div className="skeleton-line" style={{ width: 120, height: 28, marginBottom: 24 }}></div>
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div className="cm-field" key={i}>
+                <div className="skeleton-line" style={{ width: 100, height: 14, marginBottom: 8 }}></div>
+                <div className="skeleton-block" style={{ width: "100%", height: 44, borderRadius: 8 }}></div>
+              </div>
+            ))}
+          </div>
+          <div className="cm-editor-sidebar">
+            <div className="skeleton-block" style={{ width: "100%", height: 120, borderRadius: 8, marginBottom: 16 }}></div>
+            <div className="skeleton-block" style={{ width: "100%", height: 80, borderRadius: 8 }}></div>
+          </div>
+        </div>
+      ) : error ? (
+        <div className="mod-error-state" role="alert">
+          <AlertCircle size={48} color="var(--color-danger)" style={{ margin: "0 auto 16px" }} />
+          <h2>Something went wrong</h2>
+          <p className="mod-error-message">{error}</p>
+          <Link href={dest.backUrl} className="btn btn-primary" style={{ marginTop: 24, display: "inline-block" }}>
+            Back to Content Management
+          </Link>
+        </div>
+      ) : (
+        <div className="cm-editor-layout">
+          <div className="cm-editor-main">
+            <div className="cm-editor-type-badge" style={{ "--dest-color": dest.color } as React.CSSProperties}>
+              {dest.label}
+            </div>
+
+            <form className="cm-editor-form" noValidate onSubmit={(e) => e.preventDefault()}>
+              {visibleFields.map((key) => {
+                const def = FIELD_DEFS[key];
+                if (!def) return null;
+                const required = isFieldRequired(type, key, formData);
+                const value = formData[key];
+
+                if (key === "image") {
+                  return (
+                    <ImageField
+                      key={key}
+                      fieldKey={key}
+                      def={def}
+                      value={String(value || "")}
+                      required={required}
+                      onChange={(v) => setField(key, v)}
+                      onUploadingChange={setImageUploading}
+                    />
+                  );
+                }
+
+                return (
+                  <FieldRenderer
+                    key={key}
+                    fieldKey={key}
+                    def={def}
+                    value={value as string | boolean}
+                    required={required}
+                    onChange={(v) => setField(key, v)}
+                  />
+                );
+              })}
+            </form>
+          </div>
+
+          <aside className="cm-editor-sidebar" aria-label="Publishing options">
+            <div className="cm-editor-panel">
+              <h3 className="cm-editor-panel-title">Status</h3>
+              <div className="cm-status-select-wrap">
+                <select
+                  className="cm-editor-select"
+                  aria-label="Content status"
+                  value={formData.status}
+                  onChange={(e) => setField("status", e.target.value as ContentStatus)}
+                >
+                  <option value="draft">Draft</option>
+                  <option value="published">Published</option>
+                  <option value="archived">Archived</option>
+                </select>
+              </div>
+            </div>
+
+            <div className="cm-editor-panel">
+              <h3 className="cm-editor-panel-title">Visibility</h3>
+              <label className="cm-checkbox-label">
+                <input
+                  type="checkbox"
+                  className="cm-checkbox"
+                  checked={Boolean(formData.featured)}
+                  onChange={(e) => setField("featured", e.target.checked)}
+                />
+                <span>Featured content</span>
+              </label>
+              <p className="cm-field-hint">Featured items are highlighted in the hub.</p>
+            </div>
+
+            {feedback && (
+              <div className={`cm-save-feedback cm-feedback-${feedback.type}`} role="alert">
+                {feedback.message}
+              </div>
+            )}
+
+            <div className="cm-editor-actions">
+              <button className="btn btn-primary cm-btn-save" type="button" onClick={handleSave} disabled={saving}>
+                {saving ? "Saving…" : "Save"}
+              </button>
+              <button className="btn cm-btn-preview" type="button" onClick={openPreview}>
+                <Eye size={15} strokeWidth={2} />
+                Preview
+              </button>
+            </div>
+
+            {id && (
+              <div className="cm-editor-meta">
+                <p className="cm-meta-line">
+                  <span className="cm-meta-label">ID</span>
+                  <span className="cm-meta-value">{id}</span>
+                </p>
+                {formData.updatedAt && (
+                  <p className="cm-meta-line">
+                    <span className="cm-meta-label">Last saved</span>
+                    <span className="cm-meta-value">{new Date(formData.updatedAt).toLocaleString("en-GB")}</span>
+                  </p>
+                )}
+              </div>
+            )}
+          </aside>
+        </div>
+      )}
+
+      {previewMounted && (
+        <>
+          <div className="cm-preview-overlay" onClick={closePreview} aria-hidden="true"></div>
+          <aside
+            className={`cm-preview-drawer ${previewOpenClass ? "open" : ""}`}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Content preview"
+          >
+            <div className="cm-preview-header">
+              <h3 className="cm-preview-title">Preview</h3>
+              <button className="cm-preview-close" type="button" onClick={closePreview} aria-label="Close preview">
+                <X size={18} strokeWidth={2} />
+              </button>
+            </div>
+            <div className="cm-preview-body">
+              <PreviewContent data={formData} destColor={dest.color} />
+            </div>
+          </aside>
+        </>
+      )}
+    </main>
+  );
+}
+
+export default function ContentEditorPage() {
+  return (
+    <Suspense fallback={<div className="admin-auth-loader-spinner"></div>}>
+      <ContentEditorContent />
+    </Suspense>
+  );
+}

--- a/migration/app/(admin)/admin/(dashboard)/content-manager/page.tsx
+++ b/migration/app/(admin)/admin/(dashboard)/content-manager/page.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import { Suspense, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import {
+  Archive,
+  BookOpen,
+  Building2,
+  CheckCircle2,
+  Heart,
+  Pencil,
+  Plus,
+  RotateCcw,
+  Search,
+  Trash2,
+  Upload,
+  Users,
+} from "lucide-react";
+import { DESTINATIONS } from "@/lib/content-management";
+import { fetchAllContent, patchContentStatus } from "@/lib/api/content-management-api";
+import { AdminAuthError } from "@/lib/api/admin-dashboard-api";
+import { ContentDestination, ContentListItem, ContentStatus } from "@/types/content-management";
+
+const PAGE_SIZE = 15;
+
+const DESTINATION_ICONS: Record<ContentDestination, React.ReactNode> = {
+  resource: <BookOpen size={24} strokeWidth={1.8} />,
+  lifestyle: <Heart size={24} strokeWidth={1.8} />,
+  ngo: <Users size={24} strokeWidth={1.8} />,
+  clinic: <Building2 size={24} strokeWidth={1.8} />,
+};
+
+const STATUS_TABS: { label: string; value: ContentStatus | "" }[] = [
+  { label: "All", value: "" },
+  { label: "Published", value: "published" },
+  { label: "Draft", value: "draft" },
+  { label: "Archived", value: "archived" },
+];
+
+const fmtDate = (iso: string | null): string => {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" });
+};
+
+function ContentManagerContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const [allContent, setAllContent] = useState<ContentListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [currentStatus, setCurrentStatus] = useState<ContentStatus | "">("");
+  const [currentType, setCurrentType] = useState<ContentDestination | "">("");
+  const [searchInput, setSearchInput] = useState("");
+  const [currentQuery, setCurrentQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [pendingDelete, setPendingDelete] = useState<ContentListItem | null>(null);
+  const [actioningId, setActioningId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const urlFilter = searchParams.get("filter") as ContentDestination | null;
+    if (urlFilter && DESTINATIONS.some((d) => d.id === urlFilter)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncing the type filter from the URL's ?filter= param
+      setCurrentType(urlFilter);
+    }
+  }, [searchParams]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAllContent()
+      .then((items) => {
+        if (!cancelled) setAllContent(items);
+      })
+      .catch((error) => {
+        if (error instanceof AdminAuthError) router.replace("/admin/login");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [router]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setCurrentQuery(searchInput);
+      setCurrentPage(1);
+    }, 250);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  const stats = useMemo(() => {
+    const counts = { published: 0, draft: 0, archived: 0 };
+    allContent.forEach((c) => {
+      counts[c.status] += 1;
+    });
+    return counts;
+  }, [allContent]);
+
+  const filtered = useMemo(() => {
+    const q = currentQuery.toLowerCase().trim();
+    return allContent
+      .filter((c) => {
+        const matchStatus = !currentStatus || c.status === currentStatus;
+        const matchType = !currentType || c.type === currentType;
+        const matchQuery = !q || (c.title || "").toLowerCase().includes(q);
+        return matchStatus && matchType && matchQuery;
+      })
+      .sort((a, b) => new Date(b.updatedAt || 0).getTime() - new Date(a.updatedAt || 0).getTime());
+  }, [allContent, currentStatus, currentType, currentQuery]);
+
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE) || 0;
+  const pageItems = filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const updateItemStatus = (item: ContentListItem, nextStatus: ContentStatus) => {
+    setAllContent((prev) => prev.map((c) => (c.id === item.id && c.type === item.type ? { ...c, status: nextStatus } : c)));
+  };
+
+  const handleStatusAction = async (item: ContentListItem, nextStatus: ContentStatus) => {
+    const key = `${item.type}-${item.id}`;
+    setActioningId(key);
+    try {
+      await patchContentStatus(item.type, item.id, nextStatus);
+      updateItemStatus(item, nextStatus);
+    } catch (error) {
+      if (error instanceof AdminAuthError) router.replace("/admin/login");
+    } finally {
+      setActioningId(null);
+    }
+  };
+
+  const confirmDelete = async () => {
+    if (!pendingDelete) return;
+    const item = pendingDelete;
+    setPendingDelete(null);
+    await handleStatusAction(item, "archived");
+  };
+
+  return (
+    <main className="dashboard-content" id="main-content">
+      <div className="cm-page-header">
+        <div>
+          <h1 className="cm-page-title">Content Management</h1>
+          <p className="cm-page-subtitle">Create, edit, and manage all platform content from one place.</p>
+        </div>
+        <div className="cm-header-stats" aria-live="polite">
+          <div className="cm-stat-pill">
+            <span className="cm-stat-dot cm-dot-published"></span>
+            {loading ? "—" : stats.published} published
+          </div>
+          <div className="cm-stat-pill">
+            <span className="cm-stat-dot cm-dot-draft"></span>
+            {loading ? "—" : stats.draft} drafts
+          </div>
+          <div className="cm-stat-pill">
+            <span className="cm-stat-dot cm-dot-archived"></span>
+            {loading ? "—" : stats.archived} archived
+          </div>
+        </div>
+      </div>
+
+      <section aria-labelledby="destinations-heading">
+        <h2 className="cm-section-title" id="destinations-heading">
+          Destinations
+        </h2>
+        <div className="cm-destination-grid">
+          {DESTINATIONS.map((d) => {
+            const count = allContent.filter((c) => c.type === d.id).length;
+            return (
+              <div
+                className="cm-dest-card"
+                key={d.id}
+                style={{ "--dest-color": d.color, "--dest-bg": d.bgColor } as React.CSSProperties}
+              >
+                <div className="cm-dest-icon">{DESTINATION_ICONS[d.id]}</div>
+                <div className="cm-dest-body">
+                  <h3 className="cm-dest-title">{d.label}</h3>
+                  <p className="cm-dest-desc">{d.desc}</p>
+                  <p className="cm-dest-desc" style={{ marginTop: 4, fontWeight: 600 }}>
+                    {loading ? "—" : count} {count === 1 ? "entry" : "entries"}
+                  </p>
+                </div>
+                <div className="cm-dest-footer">
+                  {d.newUrl ? (
+                    <Link href={d.newUrl} className="cm-dest-new-btn" aria-label={`Add new ${d.label} entry`}>
+                      <Plus size={14} strokeWidth={2.5} />
+                      New
+                    </Link>
+                  ) : (
+                    <button
+                      type="button"
+                      className="cm-dest-new-btn"
+                      disabled
+                      title="NGOs are added through public submissions — review them from the moderation queue."
+                    >
+                      <Plus size={14} strokeWidth={2.5} />
+                      New
+                    </button>
+                  )}
+                  <button
+                    className="cm-dest-import-btn"
+                    aria-label={`Bulk import ${d.label}`}
+                    disabled
+                    title="Import coming soon"
+                  >
+                    <Upload size={14} strokeWidth={2} />
+                    Import
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <section aria-labelledby="recent-heading">
+        <div className="cm-section-header">
+          <h2 className="cm-section-title" id="recent-heading">
+            All Content
+          </h2>
+          <div className="cm-table-controls">
+            <div className="cm-search-wrap">
+              <Search size={15} className="cm-search-icon" aria-hidden="true" />
+              <input
+                type="search"
+                className="cm-search-input"
+                placeholder="Search content…"
+                aria-label="Search all content"
+                autoComplete="off"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+              />
+            </div>
+            <div className="cm-filter-tabs" role="group" aria-label="Filter by status">
+              {STATUS_TABS.map((tab) => (
+                <button
+                  key={tab.label}
+                  className={`cm-filter-btn ${currentStatus === tab.value ? "active" : ""}`}
+                  onClick={() => {
+                    setCurrentStatus(tab.value);
+                    setCurrentPage(1);
+                  }}
+                  type="button"
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+            <select
+              className="cm-select"
+              aria-label="Filter by content type"
+              value={currentType}
+              onChange={(e) => {
+                setCurrentType(e.target.value as ContentDestination | "");
+                setCurrentPage(1);
+              }}
+            >
+              <option value="">All types</option>
+              {DESTINATIONS.map((d) => (
+                <option value={d.id} key={d.id}>
+                  {d.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="cm-table-wrap">
+          <table className="cm-table" aria-label="All content entries">
+            <thead>
+              <tr className="cm-thead-row">
+                <th className="cm-th cm-th-title">Title</th>
+                <th className="cm-th">Type</th>
+                <th className="cm-th">Status</th>
+                <th className="cm-th cm-th-date">Updated</th>
+                <th className="cm-th cm-th-actions">
+                  <span className="visually-hidden">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody aria-live="polite">
+              {loading
+                ? Array.from({ length: 8 }).map((_, i) => (
+                    <tr className="cm-table-row" aria-hidden="true" key={i}>
+                      <td className="cm-td">
+                        <div className="skeleton-line" style={{ width: 200 }}></div>
+                      </td>
+                      <td className="cm-td">
+                        <div className="skeleton-line" style={{ width: 80, borderRadius: 999 }}></div>
+                      </td>
+                      <td className="cm-td">
+                        <div className="skeleton-line" style={{ width: 70, borderRadius: 999 }}></div>
+                      </td>
+                      <td className="cm-td">
+                        <div className="skeleton-line" style={{ width: 90 }}></div>
+                      </td>
+                      <td className="cm-td"></td>
+                    </tr>
+                  ))
+                : pageItems.map((item) => {
+                    const dest = DESTINATIONS.find((d) => d.id === item.type) || DESTINATIONS[0];
+                    const editUrl = `/admin/content-manager/editor?type=${item.type}&id=${encodeURIComponent(item.id)}`;
+                    const actionKey = `${item.type}-${item.id}`;
+                    const isActioning = actioningId === actionKey;
+
+                    return (
+                      <tr className="cm-table-row" key={actionKey}>
+                        <td className="cm-td cm-td-title">
+                          <div className="cm-td-title-wrap">
+                            <span className="cm-entry-title">{item.title || "Untitled"}</span>
+                          </div>
+                        </td>
+                        <td className="cm-td">
+                          <span
+                            className="cm-type-badge"
+                            style={{ "--dest-color": dest.color, "--dest-bg": dest.bgColor } as React.CSSProperties}
+                          >
+                            {dest.label}
+                          </span>
+                        </td>
+                        <td className="cm-td">
+                          <span className={`cm-status-badge cm-status-${item.status}`}>{item.status}</span>
+                        </td>
+                        <td className="cm-td cm-td-date">{fmtDate(item.updatedAt)}</td>
+                        <td className="cm-td cm-td-actions">
+                          <div className="cm-row-actions">
+                            <Link
+                              href={editUrl}
+                              className="cm-action-icon"
+                              title="Edit"
+                              aria-label={`Edit ${item.title}`}
+                            >
+                              <Pencil size={15} strokeWidth={2} />
+                            </Link>
+
+                            {item.status !== "archived" ? (
+                              <button
+                                className="cm-action-icon"
+                                disabled={isActioning}
+                                onClick={() =>
+                                  handleStatusAction(item, item.status === "published" ? "archived" : "published")
+                                }
+                                title={item.status === "published" ? "Archive" : "Publish"}
+                                aria-label={`${item.status === "published" ? "Archive" : "Publish"} ${item.title}`}
+                              >
+                                {item.status === "published" ? (
+                                  <Archive size={15} strokeWidth={2} />
+                                ) : (
+                                  <CheckCircle2 size={15} strokeWidth={2} />
+                                )}
+                              </button>
+                            ) : (
+                              <button
+                                className="cm-action-icon"
+                                disabled={isActioning}
+                                onClick={() => handleStatusAction(item, "draft")}
+                                title="Restore to draft"
+                                aria-label={`Restore ${item.title} to draft`}
+                              >
+                                <RotateCcw size={15} strokeWidth={2} />
+                              </button>
+                            )}
+
+                            <button
+                              className="cm-action-icon cm-action-delete"
+                              disabled={isActioning}
+                              onClick={() => setPendingDelete(item)}
+                              title="Delete"
+                              aria-label={`Delete ${item.title}`}
+                            >
+                              <Trash2 size={15} strokeWidth={2} />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
+            </tbody>
+          </table>
+
+          {!loading && pageItems.length === 0 && (
+            <p className="cm-empty" role="status">
+              {currentQuery || currentStatus || currentType
+                ? "No content matches your filters."
+                : "No content yet. Use the destination cards above to add your first entry."}
+            </p>
+          )}
+        </div>
+
+        {totalPages > 1 && (
+          <div className="pagination-wrap" aria-live="polite">
+            <nav className="pagination" aria-label="Content list pagination">
+              <button
+                className="pagination-btn"
+                disabled={currentPage === 1}
+                onClick={() => setCurrentPage((p) => p - 1)}
+              >
+                ← Prev
+              </button>
+              <div className="pagination-pages">
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+                  <button
+                    key={p}
+                    className={`pagination-page ${p === currentPage ? "pagination-page-active" : ""}`}
+                    aria-current={p === currentPage ? "page" : undefined}
+                    onClick={() => setCurrentPage(p)}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+              <button
+                className="pagination-btn"
+                disabled={currentPage === totalPages}
+                onClick={() => setCurrentPage((p) => p + 1)}
+              >
+                Next →
+              </button>
+            </nav>
+          </div>
+        )}
+      </section>
+
+      {pendingDelete && (
+        <div className="cm-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="delete-modal-title">
+          <div className="cm-modal">
+            <h3 className="cm-modal-title" id="delete-modal-title">
+              Delete content?
+            </h3>
+            <p className="cm-modal-body">&quot;{pendingDelete.title}&quot; will be archived. You can restore it later.</p>
+            <div className="cm-modal-actions">
+              <button className="btn cm-btn-cancel" type="button" onClick={() => setPendingDelete(null)}>
+                Cancel
+              </button>
+              <button className="btn cm-btn-delete" type="button" onClick={confirmDelete}>
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}
+
+export default function ContentManagerPage() {
+  return (
+    <Suspense fallback={<div className="admin-auth-loader-spinner"></div>}>
+      <ContentManagerContent />
+    </Suspense>
+  );
+}

--- a/migration/lib/api/content-management-api.ts
+++ b/migration/lib/api/content-management-api.ts
@@ -1,0 +1,193 @@
+import api, { ApiError } from "../api";
+import { getDestination, mapNgoStatusToContentStatus, normalizeStatus, toEditorFormData } from "../content-management";
+import { AdminAuthError } from "./admin-dashboard-api";
+import {
+  AdminClinicDetailResponse,
+  AdminClinicsListResponse,
+  AdminImageUploadResponse,
+  AdminLifestyleDetailResponse,
+  AdminLifestyleListResponse,
+  AdminNgoDetailResponse,
+  AdminNgosListResponse,
+  AdminResourceDetailResponse,
+  AdminResourcesListResponse,
+  ContentDestination,
+  ContentFormData,
+  ContentListItem,
+} from "@/types/content-management";
+
+const isAuthError = (error: unknown): boolean =>
+  error instanceof ApiError && (error.status === 401 || error.status === 403);
+
+const rejectsWithAuthError = (results: PromiseSettledResult<unknown>[]): boolean =>
+  results.some((r) => r.status === "rejected" && isAuthError(r.reason));
+
+export async function fetchAllContent(): Promise<ContentListItem[]> {
+  const [resourcesRes, lifestyleRes, ngosRes, clinicsRes] = await Promise.allSettled([
+    api.get<AdminResourcesListResponse>("/api/v1/admin/resources"),
+    api.get<AdminLifestyleListResponse>("/api/v1/admin/lifestyle"),
+    api.get<AdminNgosListResponse>("/api/v1/admin/ngos"),
+    api.get<AdminClinicsListResponse>("/api/v1/admin/clinics"),
+  ]);
+
+  if (rejectsWithAuthError([resourcesRes, lifestyleRes, ngosRes, clinicsRes])) {
+    throw new AdminAuthError();
+  }
+
+  const items: ContentListItem[] = [];
+
+  if (resourcesRes.status === "fulfilled") {
+    (resourcesRes.value.data?.resources || []).forEach((item) =>
+      items.push({
+        id: item.id,
+        title: item.title,
+        type: "resource",
+        status: normalizeStatus(item.status),
+        updatedAt: item.updatedAt,
+      })
+    );
+  }
+
+  if (lifestyleRes.status === "fulfilled") {
+    (lifestyleRes.value.data?.lifestyle || []).forEach((item) =>
+      items.push({
+        id: item.id,
+        title: item.title,
+        type: "lifestyle",
+        status: normalizeStatus(item.status),
+        updatedAt: item.updatedAt,
+      })
+    );
+  }
+
+  if (ngosRes.status === "fulfilled") {
+    (ngosRes.value.data?.ngos || []).forEach((item) =>
+      items.push({
+        id: item.id,
+        title: item.name,
+        type: "ngo",
+        status: mapNgoStatusToContentStatus(item.status),
+        updatedAt: item.updatedAt,
+      })
+    );
+  }
+
+  if (clinicsRes.status === "fulfilled") {
+    (clinicsRes.value.data?.clinics || []).forEach((item) =>
+      items.push({
+        id: item.id,
+        title: item.name,
+        type: "clinic",
+        status: normalizeStatus(item.status),
+        updatedAt: item.updatedAt,
+      })
+    );
+  }
+
+  return items;
+}
+
+export async function patchContentStatus(
+  type: ContentDestination,
+  id: string,
+  nextStatus: ContentFormData["status"]
+): Promise<void> {
+  const dest = getDestination(type);
+  const payload =
+    type === "ngo"
+      ? { status: mapNgoStatusToContentStatus(nextStatus) }
+      : { status: nextStatus };
+
+  try {
+    await api.patch(`${dest.apiBase}/${id}`, payload);
+  } catch (error) {
+    if (isAuthError(error)) throw new AdminAuthError();
+    throw error;
+  }
+}
+
+export async function fetchContentEntry(
+  type: ContentDestination,
+  id: string
+): Promise<ContentFormData | null> {
+  const dest = getDestination(type);
+
+  try {
+    const res = await api.get<
+      | AdminResourceDetailResponse
+      | AdminLifestyleDetailResponse
+      | AdminNgoDetailResponse
+      | AdminClinicDetailResponse
+    >(`${dest.apiBase}/${id}`);
+
+    const raw =
+      (res.data as AdminResourceDetailResponse["data"]).resource ||
+      (res.data as AdminLifestyleDetailResponse["data"]).lifestyle ||
+      (res.data as AdminNgoDetailResponse["data"]).ngo ||
+      (res.data as AdminClinicDetailResponse["data"]).clinic ||
+      null;
+
+    if (!raw) return null;
+    return toEditorFormData(type, raw as unknown as Record<string, unknown>);
+  } catch (error) {
+    if (isAuthError(error)) throw new AdminAuthError();
+    throw error;
+  }
+}
+
+interface SaveContentResult {
+  id: string;
+  formData: ContentFormData;
+}
+
+export async function saveContentEntry(
+  type: ContentDestination,
+  id: string | null,
+  payload: Record<string, unknown>
+): Promise<SaveContentResult> {
+  const dest = getDestination(type);
+
+  try {
+    const res = id
+      ? await api.patch<
+          | AdminResourceDetailResponse
+          | AdminLifestyleDetailResponse
+          | AdminNgoDetailResponse
+          | AdminClinicDetailResponse
+        >(`${dest.apiBase}/${id}`, payload)
+      : await api.post<
+          | AdminResourceDetailResponse
+          | AdminLifestyleDetailResponse
+          | AdminNgoDetailResponse
+          | AdminClinicDetailResponse
+        >(dest.apiBase, payload);
+
+    const raw =
+      (res.data as AdminResourceDetailResponse["data"]).resource ||
+      (res.data as AdminLifestyleDetailResponse["data"]).lifestyle ||
+      (res.data as AdminNgoDetailResponse["data"]).ngo ||
+      (res.data as AdminClinicDetailResponse["data"]).clinic;
+
+    return {
+      id: raw.id,
+      formData: toEditorFormData(type, raw as unknown as Record<string, unknown>),
+    };
+  } catch (error) {
+    if (isAuthError(error)) throw new AdminAuthError();
+    throw error;
+  }
+}
+
+export async function uploadContentImage(dataUrl: string): Promise<string> {
+  try {
+    const res = await api.post<AdminImageUploadResponse>("/api/v1/admin/upload/image", {
+      image: dataUrl,
+    });
+    const url = res.data?.imageUrl || res.data?.image_url;
+    if (!url) throw new Error("Missing uploaded image URL.");
+    return url;
+  } catch (error) {
+    if (isAuthError(error)) throw new AdminAuthError();
+    throw error;
+  }
+}

--- a/migration/lib/content-management.ts
+++ b/migration/lib/content-management.ts
@@ -265,6 +265,7 @@ export const FIELD_DEFS: Record<string, FieldDef> = {
     type: "select",
     required: true,
     options: [
+      { value: "", label: "Choose type…" },
       { value: "clinic", label: "Clinic" },
       { value: "therapist", label: "Therapist" },
       { value: "psychiatrist", label: "Psychiatrist" },
@@ -378,7 +379,7 @@ const RESOURCE_TYPE_SPECIFIC_FIELDS: Record<string, string[]> = {
 
 const ALL_RESOURCE_TYPE_SPECIFIC_FIELDS = Object.values(RESOURCE_TYPE_SPECIFIC_FIELDS).flat();
 
-export function getNormalizedResourceType(data: ContentFormData): string {
+export function getNormalizedResourceType(data: Record<string, unknown>): string {
   const raw = String(data.content_type || "").trim().toLowerCase();
   if (!raw) return "article";
   if (raw === "audio" || raw === "podcast" || raw === "video") return "media";
@@ -560,7 +561,7 @@ export function mapContentStatusToNgoStatus(status: ContentStatus | string | und
 export function toEditorFormData(type: ContentDestination, raw: Record<string, unknown>): ContentFormData {
   if (type === "resource") {
     const r = raw as unknown as AdminResourceRaw;
-    const selectedType = getNormalizedResourceType({ content_type: r.content_type } as ContentFormData);
+    const selectedType = getNormalizedResourceType({ content_type: r.content_type });
     const structured = r.structured_content ?? null;
     const articleBody = String(r.content || r.summary || "").trim();
 

--- a/migration/lib/content-management.ts
+++ b/migration/lib/content-management.ts
@@ -1,0 +1,744 @@
+import {
+  AdminClinicRaw,
+  AdminLifestyleRaw,
+  AdminNgoRaw,
+  AdminResourceRaw,
+  ContentDestination,
+  ContentFormData,
+  ContentStatus,
+  DestinationConfig,
+  FieldDef,
+  NgoStatus,
+} from "@/types/content-management";
+import { ArticleBlock, InfographicContent, MediaContent, MythBustingContent } from "@/types/resource";
+
+// ── Destinations ──────────────────────────────────────────────────────────────
+// Mirrors client/js/pages/content-management.js DESTINATIONS + content-editor.js
+// TYPE_CONFIG (merged — client kept these in two files with duplicated labels).
+// NGO has no `newUrl`: there's no admin "create NGO" endpoint, only public
+// submission + admin review (see server/routes/adminNgosRouter.js).
+export const DESTINATIONS: DestinationConfig[] = [
+  {
+    id: "resource",
+    label: "Resource Hub",
+    desc: "Articles, infographics, audio summaries, podcasts, myth-busting guides.",
+    color: "var(--color-brand-400)",
+    bgColor: "var(--color-brand-50)",
+    fields: [
+      "title",
+      "summary",
+      "content_type",
+      "theme",
+      "image",
+      "source_url",
+      "read_time",
+      "cta_label",
+      "body",
+      "article_blocks",
+      "infographic_title",
+      "infographic_tagline",
+      "infographic_items",
+      "myths",
+      "facts",
+      "media_format",
+      "file_url",
+      "summary_paragraphs",
+    ],
+    apiBase: "/api/v1/admin/resources",
+    backUrl: "/admin/content-manager?filter=resource",
+    newUrl: "/admin/content-manager/editor?type=resource",
+  },
+  {
+    id: "lifestyle",
+    label: "Lifestyle Hub",
+    desc: "Lifestyle and medical interventions for postpartum support.",
+    color: "#7c3aed",
+    bgColor: "#f5f3ff",
+    fields: ["title", "category", "subtitle", "summary", "foundation", "tips", "evidence"],
+    apiBase: "/api/v1/admin/lifestyle",
+    backUrl: "/admin/content-manager?filter=lifestyle",
+    newUrl: "/admin/content-manager/editor?type=lifestyle",
+  },
+  {
+    id: "ngo",
+    label: "NGO Directory",
+    desc: "NGOs and support organisations providing maternal health services.",
+    color: "#0369a1",
+    bgColor: "#f0f9ff",
+    fields: ["title", "mission", "services", "coverage", "website", "email", "phone", "image"],
+    apiBase: "/api/v1/admin/ngos",
+    backUrl: "/admin/content-manager?filter=ngo",
+  },
+  {
+    id: "clinic",
+    label: "Clinic Directory",
+    desc: "Verified healthcare providers offering postpartum mental health support.",
+    color: "#15803d",
+    bgColor: "#f0fdf4",
+    fields: [
+      "title",
+      "provider_type",
+      "description",
+      "services",
+      "city",
+      "state",
+      "address",
+      "opening_hours",
+      "fee_range",
+      "contact_email",
+      "contact_phone",
+      "website",
+      "image",
+      "accepting_new_patients",
+    ],
+    apiBase: "/api/v1/admin/clinics",
+    backUrl: "/admin/content-manager?filter=clinic",
+    newUrl: "/admin/content-manager/editor?type=clinic",
+  },
+];
+
+export const getDestination = (type: string): DestinationConfig =>
+  DESTINATIONS.find((d) => d.id === type) || DESTINATIONS[0];
+
+// ── Field definitions ─────────────────────────────────────────────────────────
+// Mirrors content-editor.js FIELD_DEFS. Dropped a few entries client defined
+// but never wired into any DESTINATIONS.fields list (tags, speciality,
+// credentials, languages, consultation_types, location, source_label,
+// is_medical) — they rendered nothing and matched no backend field.
+export const FIELD_DEFS: Record<string, FieldDef> = {
+  title: {
+    label: "Title",
+    type: "text",
+    required: true,
+    placeholder: "Enter a clear, descriptive title",
+  },
+  summary: {
+    label: "Summary",
+    type: "textarea",
+    rows: 2,
+    placeholder: "Short description shown on cards (150 chars max)",
+    hint: "Shown on resource cards in the hub.",
+  },
+  foundation: {
+    label: "Foundation paragraphs",
+    type: "textarea",
+    rows: 6,
+    required: true,
+    placeholder: "One paragraph per line",
+    hint: "Each line becomes a paragraph in the Foundation section.",
+  },
+  tips: {
+    label: "Practical strategies",
+    type: "textarea",
+    rows: 6,
+    required: true,
+    placeholder: "Tip title | Tip description",
+    hint: "One tip per line in the format: title | description",
+  },
+  evidence: {
+    label: "Clinical evidence",
+    type: "textarea",
+    rows: 6,
+    required: true,
+    placeholder: "One evidence point per line",
+  },
+  description: {
+    label: "Description",
+    type: "textarea",
+    rows: 3,
+    placeholder: "Describe this entry",
+  },
+  body: {
+    label: "Full content",
+    type: "textarea",
+    rows: 10,
+    placeholder: "Full article body…",
+    hint: "Used for article resources as the main content.",
+  },
+  article_blocks: {
+    label: "Article blocks",
+    type: "textarea",
+    rows: 8,
+    placeholder: "One paragraph per block. Separate paragraphs with a blank line.",
+    hint: "For article type. Each paragraph becomes a structured paragraph block.",
+  },
+  content_type: {
+    label: "Content type",
+    type: "select",
+    required: true,
+    options: [
+      { value: "", label: "Choose type…" },
+      { value: "article", label: "Article" },
+      { value: "infographic", label: "Infographic" },
+      { value: "media", label: "Media" },
+      { value: "myth-busting", label: "Myth-Busting Guide" },
+    ],
+  },
+  cta_label: {
+    label: "CTA label",
+    type: "text",
+    required: true,
+    placeholder: "e.g. Read more, Listen now, View guide",
+    hint: "Button label shown on resource cards.",
+  },
+  infographic_title: {
+    label: "Infographic title",
+    type: "text",
+    placeholder: "Main infographic headline",
+  },
+  infographic_tagline: {
+    label: "Infographic tagline",
+    type: "text",
+    placeholder: "Short closing line",
+  },
+  infographic_items: {
+    label: "Infographic items",
+    type: "textarea",
+    rows: 6,
+    placeholder: "icon | label\nicon | label",
+    hint: "One item per line in the format: icon | label",
+  },
+  myths: {
+    label: "Myths",
+    type: "textarea",
+    rows: 6,
+    placeholder: "Myth 1 | Description\nMyth 2 | Description",
+    hint: "One myth per line in the format: label | description",
+  },
+  facts: {
+    label: "Facts",
+    type: "textarea",
+    rows: 6,
+    placeholder: "Fact 1 | Description\nFact 2 | Description",
+    hint: "One fact per line in the format: label | description",
+  },
+  media_format: {
+    label: "Media format",
+    type: "select",
+    required: true,
+    options: [
+      { value: "audio", label: "Audio" },
+      { value: "podcast", label: "Podcast" },
+      { value: "video", label: "Video" },
+    ],
+  },
+  file_url: {
+    label: "Media file URL",
+    type: "url",
+    required: true,
+    placeholder: "https://…",
+    hint: "Direct audio/video file URL used by the media player.",
+  },
+  summary_paragraphs: {
+    label: "Media summary paragraphs",
+    type: "textarea",
+    rows: 6,
+    required: true,
+    placeholder: "One paragraph per line",
+    hint: "Used beneath the media player. Enter one paragraph per line.",
+  },
+  theme: {
+    label: "Theme",
+    type: "select",
+    required: true,
+    options: [
+      { value: "", label: "Choose theme…" },
+      { value: "symptoms", label: "Symptoms" },
+      { value: "causes", label: "Causes" },
+      { value: "treatment", label: "Treatment" },
+      { value: "recovery", label: "Recovery" },
+      { value: "general", label: "General" },
+    ],
+  },
+  category: {
+    label: "Category",
+    type: "select",
+    required: true,
+    options: [
+      { value: "", label: "Choose category…" },
+      { value: "lifestyle", label: "Lifestyle Change" },
+      { value: "medical", label: "Medical Option" },
+    ],
+  },
+  provider_type: {
+    label: "Provider type",
+    type: "select",
+    required: true,
+    options: [
+      { value: "clinic", label: "Clinic" },
+      { value: "therapist", label: "Therapist" },
+      { value: "psychiatrist", label: "Psychiatrist" },
+      { value: "support_group", label: "Support Group" },
+    ],
+  },
+  mission: {
+    label: "Mission / Focus",
+    type: "textarea",
+    rows: 3,
+    required: true,
+    placeholder: "What does this organisation do?",
+  },
+  services: {
+    label: "Services offered",
+    type: "textarea",
+    rows: 3,
+    placeholder: "One service per line",
+    hint: "Enter each service on a new line.",
+  },
+  coverage: {
+    label: "Geographic coverage",
+    type: "text",
+    placeholder: "e.g. Lagos, South-West Nigeria, National",
+  },
+  city: {
+    label: "City",
+    type: "text",
+    required: true,
+    placeholder: "e.g. Lagos",
+  },
+  state: {
+    label: "State",
+    type: "text",
+    required: true,
+    placeholder: "e.g. Lagos State",
+  },
+  address: {
+    label: "Full address",
+    type: "text",
+    placeholder: "Street address",
+  },
+  opening_hours: {
+    label: "Opening hours",
+    type: "text",
+    placeholder: "e.g. Mon–Fri 8am–5pm",
+  },
+  fee_range: {
+    label: "Fee range",
+    type: "text",
+    placeholder: "e.g. ₦5,000–₦15,000",
+  },
+  source_url: {
+    label: "Source / reference URL",
+    type: "url",
+    required: true,
+    placeholder: "https://…",
+  },
+  website: {
+    label: "Website URL",
+    type: "url",
+    placeholder: "https://…",
+  },
+  email: {
+    label: "Email",
+    type: "email",
+    placeholder: "contact@organisation.org",
+  },
+  contact_email: {
+    label: "Contact email",
+    type: "email",
+    placeholder: "contact@example.com",
+  },
+  phone: {
+    label: "Phone",
+    type: "tel",
+    placeholder: "+234 …",
+  },
+  contact_phone: {
+    label: "Contact phone",
+    type: "tel",
+    placeholder: "+234 …",
+  },
+  read_time: {
+    label: "Read time",
+    type: "text",
+    required: true,
+    placeholder: "e.g. 5 min read",
+  },
+  image: {
+    label: "Image URL",
+    type: "url",
+    required: true,
+    placeholder: "https://… (paste image URL or upload via file)",
+    hint: "Paste a URL or leave blank to upload a file.",
+  },
+  accepting_new_patients: {
+    label: "Accepting new patients",
+    type: "checkbox",
+  },
+};
+
+// ── Resource sub-type visibility ──────────────────────────────────────────────
+
+const RESOURCE_TYPE_SPECIFIC_FIELDS: Record<string, string[]> = {
+  article: ["body", "article_blocks"],
+  infographic: ["infographic_title", "infographic_tagline", "infographic_items"],
+  "myth-busting": ["myths", "facts"],
+  media: ["media_format", "file_url", "summary_paragraphs"],
+};
+
+const ALL_RESOURCE_TYPE_SPECIFIC_FIELDS = Object.values(RESOURCE_TYPE_SPECIFIC_FIELDS).flat();
+
+export function getNormalizedResourceType(data: ContentFormData): string {
+  const raw = String(data.content_type || "").trim().toLowerCase();
+  if (!raw) return "article";
+  if (raw === "audio" || raw === "podcast" || raw === "video") return "media";
+  if (raw === "myth_busting") return "myth-busting";
+  return raw;
+}
+
+export function getVisibleFields(type: ContentDestination, fields: string[], data: ContentFormData): string[] {
+  if (type !== "resource") return fields;
+
+  const selectedType = getNormalizedResourceType(data);
+  const sharedFields = fields.filter((field) => !ALL_RESOURCE_TYPE_SPECIFIC_FIELDS.includes(field));
+  return [...sharedFields, ...(RESOURCE_TYPE_SPECIFIC_FIELDS[selectedType] || [])];
+}
+
+const RESOURCE_REQUIRED_BY_TYPE: Record<string, string[]> = {
+  article: ["body", "article_blocks"],
+  infographic: ["infographic_title", "infographic_tagline", "infographic_items"],
+  "myth-busting": ["myths", "facts"],
+  media: ["file_url", "summary_paragraphs", "media_format"],
+};
+
+const RESOURCE_BASE_REQUIRED = ["title", "summary", "content_type", "theme", "image", "source_url", "read_time", "cta_label"];
+
+export function isFieldRequired(type: ContentDestination, key: string, data: ContentFormData): boolean {
+  if (type !== "resource") {
+    return Boolean(FIELD_DEFS[key]?.required);
+  }
+
+  if (RESOURCE_BASE_REQUIRED.includes(key)) return true;
+
+  const selectedType = getNormalizedResourceType(data);
+  return (RESOURCE_REQUIRED_BY_TYPE[selectedType] || []).includes(key);
+}
+
+// ── String <-> structured-value helpers ───────────────────────────────────────
+
+export function splitLines(value: unknown = ""): string[] {
+  return String(value ?? "")
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function splitParagraphs(value: unknown = ""): string[] {
+  return String(value ?? "")
+    .split(/\n\s*\n/g)
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function getFirstNonEmptyString(...values: Array<string | undefined | null>): string {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+interface PipeItem {
+  label: string;
+  description: string;
+}
+
+function parsePipeList(value: unknown = ""): PipeItem[] {
+  return splitLines(value)
+    .map((line) => {
+      const [left, ...rest] = line.split("|");
+      const label = String(left || "").trim();
+      const description = rest.join("|").trim();
+      return label && description ? { label, description } : null;
+    })
+    .filter((item): item is PipeItem => item !== null);
+}
+
+interface InfographicItemInput {
+  icon: string;
+  label: string;
+}
+
+function parseInfographicItems(value: unknown = ""): InfographicItemInput[] {
+  return splitLines(value)
+    .map((line) => {
+      const [left, ...rest] = line.split("|");
+      const icon = String(left || "").trim();
+      const label = rest.join("|").trim();
+      return icon && label ? { icon, label } : null;
+    })
+    .filter((item): item is InfographicItemInput => item !== null);
+}
+
+function toPipeList(items: PipeItem[] | undefined): string {
+  if (!Array.isArray(items)) return "";
+  return items
+    .map((item) => {
+      const label = String(item?.label || "").trim();
+      const description = String(item?.description || "").trim();
+      return label && description ? `${label} | ${description}` : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function toInfographicLines(items: InfographicItemInput[] | undefined): string {
+  if (!Array.isArray(items)) return "";
+  return items
+    .map((item) => {
+      const icon = String(item?.icon || "").trim();
+      const label = String(item?.label || "").trim();
+      return icon && label ? `${icon} | ${label}` : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function toArticleBlocksText(structuredContent: unknown, fallbackBody = ""): string {
+  if (!Array.isArray(structuredContent) || structuredContent.length === 0) {
+    return fallbackBody || "";
+  }
+
+  const paragraphs = (structuredContent as ArticleBlock[])
+    .filter((block) => block?.type === "paragraph" && typeof (block as { text?: unknown }).text === "string")
+    .map((block) => (block as { text: string }).text.trim())
+    .filter(Boolean);
+
+  return paragraphs.join("\n\n") || fallbackBody || "";
+}
+
+function buildResourceStructuredContent(
+  data: ContentFormData
+): ArticleBlock[] | InfographicContent | MythBustingContent | MediaContent {
+  const selectedType = getNormalizedResourceType(data);
+
+  if (selectedType === "article") {
+    return splitParagraphs(data.article_blocks || data.body).map((text) => ({
+      type: "paragraph",
+      text,
+    }));
+  }
+
+  if (selectedType === "infographic") {
+    return {
+      title: String(data.infographic_title || "").trim(),
+      tagline: String(data.infographic_tagline || "").trim(),
+      items: parseInfographicItems(data.infographic_items),
+    };
+  }
+
+  if (selectedType === "myth-busting") {
+    return {
+      myths: parsePipeList(data.myths),
+      facts: parsePipeList(data.facts),
+    };
+  }
+
+  return { summary_paragraphs: splitLines(data.summary_paragraphs) };
+}
+
+// ── Status mapping ────────────────────────────────────────────────────────────
+
+export function normalizeStatus(value: unknown): ContentStatus {
+  if (value === "published" || value === "draft" || value === "archived") return value;
+  return "draft";
+}
+
+export function mapNgoStatusToContentStatus(status: NgoStatus | string | undefined): ContentStatus {
+  if (status === "approved") return "published";
+  if (status === "rejected") return "archived";
+  return "draft";
+}
+
+export function mapContentStatusToNgoStatus(status: ContentStatus | string | undefined): NgoStatus {
+  if (status === "published") return "approved";
+  if (status === "archived") return "rejected";
+  return "pending";
+}
+
+// ── raw API record -> editor form state ───────────────────────────────────────
+
+export function toEditorFormData(type: ContentDestination, raw: Record<string, unknown>): ContentFormData {
+  if (type === "resource") {
+    const r = raw as unknown as AdminResourceRaw;
+    const selectedType = getNormalizedResourceType({ content_type: r.content_type } as ContentFormData);
+    const structured = r.structured_content ?? null;
+    const articleBody = String(r.content || r.summary || "").trim();
+
+    return {
+      type: "resource",
+      title: r.title || "",
+      summary: r.summary || "",
+      body: articleBody,
+      article_blocks: toArticleBlocksText(structured, articleBody),
+      content_type: selectedType,
+      theme: r.theme || "",
+      image: getFirstNonEmptyString(r.imageUrl, r.image_url),
+      source_url: r.source_url || "",
+      read_time: r.read_time || "",
+      cta_label: r.cta_label || "Read more",
+      infographic_title: (structured as InfographicContent)?.title || "",
+      infographic_tagline: (structured as InfographicContent)?.tagline || "",
+      infographic_items: toInfographicLines((structured as InfographicContent)?.items),
+      myths: toPipeList((structured as MythBustingContent)?.myths),
+      facts: toPipeList((structured as MythBustingContent)?.facts),
+      media_format: r.media_format || "audio",
+      file_url: r.file_url || r.source_url || "",
+      summary_paragraphs: Array.isArray((structured as MediaContent)?.summary_paragraphs)
+        ? (structured as MediaContent).summary_paragraphs.join("\n")
+        : "",
+      status: normalizeStatus(r.status ?? (r.published ? "published" : "draft")),
+      featured: Boolean(r.featured),
+      updatedAt: r.updatedAt,
+    };
+  }
+
+  if (type === "lifestyle") {
+    const r = raw as unknown as AdminLifestyleRaw;
+    return {
+      type: "lifestyle",
+      title: r.title || "",
+      category: r.category || "lifestyle",
+      subtitle: r.subtitle || "",
+      summary: r.summary || "",
+      foundation: Array.isArray(r.foundation) ? r.foundation.join("\n") : "",
+      tips: Array.isArray(r.tips)
+        ? r.tips
+            .map((tip) => {
+              const title = String(tip?.title || "").trim();
+              const desc = String(tip?.desc || "").trim();
+              return title && desc ? `${title} | ${desc}` : "";
+            })
+            .filter(Boolean)
+            .join("\n")
+        : "",
+      evidence: Array.isArray(r.evidence) ? r.evidence.join("\n") : "",
+      status: normalizeStatus(r.status),
+      featured: false,
+      updatedAt: r.updatedAt,
+    };
+  }
+
+  if (type === "ngo") {
+    const r = raw as unknown as AdminNgoRaw;
+    return {
+      type: "ngo",
+      title: r.name || "",
+      mission: r.mission || "",
+      services: Array.isArray(r.services) ? r.services.join("\n") : "",
+      coverage: r.geographic_coverage || "",
+      website: r.website || "",
+      email: r.contact?.email || "",
+      phone: r.contact?.phone || "",
+      image: r.cover_image || "",
+      status: mapNgoStatusToContentStatus(r.status),
+      featured: false,
+      updatedAt: r.updatedAt,
+    };
+  }
+
+  const r = raw as unknown as AdminClinicRaw;
+  return {
+    type: "clinic",
+    title: r.name || "",
+    provider_type: r.provider_type || "clinic",
+    description: r.description || "",
+    services: Array.isArray(r.services) ? r.services.join("\n") : "",
+    city: r.city || "",
+    state: r.state || "",
+    address: r.contact?.address || "",
+    opening_hours: r.opening_hours || "",
+    fee_range: r.fee_range || "",
+    contact_email: r.contact?.email || "",
+    contact_phone: r.contact?.phone || "",
+    website: r.website || "",
+    image: r.cover_image || "",
+    accepting_new_patients: Boolean(r.accepting_new_patients),
+    status: normalizeStatus(r.status),
+    featured: false,
+    updatedAt: r.updatedAt,
+  };
+}
+
+// ── editor form state -> API payload ──────────────────────────────────────────
+
+export function toApiPayload(type: ContentDestination, data: ContentFormData): Record<string, unknown> {
+  if (type === "resource") {
+    const selectedType = getNormalizedResourceType(data);
+    const structuredContent = buildResourceStructuredContent(data);
+    const articleContent =
+      selectedType === "article"
+        ? String(data.body || data.article_blocks || "").trim()
+        : String(data.summary || "").trim();
+
+    return {
+      title: data.title,
+      summary: data.summary,
+      content: articleContent,
+      theme: data.theme,
+      contentType: selectedType,
+      imageUrl: data.image,
+      sourceUrl: data.source_url,
+      fileUrl: data.file_url,
+      mediaFormat: data.media_format || "audio",
+      readTime: data.read_time,
+      ctaLabel: data.cta_label || "Read more",
+      structuredContent,
+      status: normalizeStatus(data.status),
+      featured: Boolean(data.featured),
+    };
+  }
+
+  if (type === "lifestyle") {
+    const tips = splitLines(data.tips)
+      .map((line) => {
+        const [left, ...rest] = line.split("|");
+        const title = String(left || "").trim();
+        const desc = rest.join("|").trim();
+        return title && desc ? { title, desc } : null;
+      })
+      .filter((tip): tip is { title: string; desc: string } => tip !== null);
+
+    return {
+      title: data.title,
+      category: data.category,
+      subtitle: data.subtitle,
+      summary: data.summary,
+      foundation: splitLines(data.foundation),
+      tips,
+      evidence: splitLines(data.evidence),
+      status: normalizeStatus(data.status),
+    };
+  }
+
+  if (type === "ngo") {
+    return {
+      name: data.title,
+      mission: data.mission,
+      services: splitLines(data.services),
+      geographic_coverage: data.coverage,
+      website: data.website,
+      email: data.email,
+      phone: data.phone,
+      cover_image: data.image,
+      status: mapContentStatusToNgoStatus(data.status),
+    };
+  }
+
+  return {
+    name: data.title,
+    provider_type: data.provider_type,
+    description: data.description,
+    services: splitLines(data.services),
+    city: data.city,
+    state: data.state,
+    address: data.address,
+    opening_hours: data.opening_hours,
+    fee_range: data.fee_range,
+    email: data.contact_email,
+    phone: data.contact_phone,
+    website: data.website,
+    cover_image: data.image,
+    accepting_new_patients: Boolean(data.accepting_new_patients),
+    status: normalizeStatus(data.status),
+  };
+}

--- a/migration/types/content-management.ts
+++ b/migration/types/content-management.ts
@@ -1,0 +1,192 @@
+import {
+  ArticleBlock,
+  ContentType as ResourceContentType,
+  InfographicContent,
+  MediaContent,
+  MediaFormat,
+  MythBustingContent,
+} from "./resource";
+
+export type ContentDestination = "resource" | "lifestyle" | "ngo" | "clinic";
+
+// draft/published/archived — what resources, lifestyle, and clinics use.
+export type ContentStatus = "draft" | "published" | "archived";
+
+// pending/approved/rejected — what NGOs use (see server/models/ngo.js).
+// The content-manager UI maps this to ContentStatus for display/filtering
+// (approved->published, rejected->archived, pending->draft); see
+// lib/content-management.ts mapNgoStatusToContentStatus / mapContentStatusToNgoStatus.
+export type NgoStatus = "pending" | "approved" | "rejected";
+
+export type FieldType = "text" | "textarea" | "select" | "checkbox" | "url" | "email" | "tel";
+
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+export interface FieldDef {
+  label: string;
+  type: FieldType;
+  required?: boolean;
+  rows?: number;
+  placeholder?: string;
+  hint?: string;
+  options?: SelectOption[];
+}
+
+export interface DestinationConfig {
+  id: ContentDestination;
+  label: string;
+  desc: string;
+  color: string;
+  bgColor: string;
+  /** Field keys (into FIELD_DEFS) shown in the editor for this type. */
+  fields: string[];
+  apiBase: string;
+  backUrl: string;
+  /**
+   * Undefined when the backend has no admin "create" endpoint for this type
+   * (NGOs are only created via public submission — see adminNgosRouter.js).
+   */
+  newUrl?: string;
+}
+
+// Unified row shown in the "All Content" table and used for destination
+// card counts + published/draft/archived stat pills.
+export interface ContentListItem {
+  id: string;
+  title: string;
+  type: ContentDestination;
+  status: ContentStatus;
+  updatedAt: string | null;
+}
+
+// Dynamic editor form state. Field values are always string (text/textarea/
+// select/url/email/tel inputs) or boolean (checkboxes) — see FieldType above.
+export interface ContentFormData {
+  type: ContentDestination;
+  status: ContentStatus;
+  featured: boolean;
+  updatedAt?: string | null;
+  [key: string]: string | boolean | ContentDestination | ContentStatus | null | undefined;
+}
+
+// ---- Raw admin list/detail API response shapes ----
+// See server/controllers/{resources,lifestyle,ngos,clinics}Controller.js
+
+export interface AdminResourceRaw {
+  id: string;
+  title: string;
+  summary: string;
+  content: string;
+  theme: string;
+  content_type: ResourceContentType;
+  imageUrl: string;
+  image_url: string;
+  source_url?: string;
+  file_url?: string;
+  media_format?: MediaFormat;
+  read_time: string;
+  cta_label: string;
+  structured_content?: ArticleBlock[] | InfographicContent | MythBustingContent | MediaContent | null;
+  status: ContentStatus;
+  published: boolean;
+  featured?: boolean;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface AdminLifestyleTip {
+  title: string;
+  desc: string;
+}
+
+export interface AdminLifestyleRaw {
+  id: string; // slug, falls back to _id — see normalizeLifestyle in lifestyleController.js
+  title: string;
+  category: "lifestyle" | "medical";
+  subtitle: string;
+  summary: string;
+  foundation: string[];
+  tips: AdminLifestyleTip[];
+  evidence: string[];
+  status: ContentStatus;
+  updatedAt: string | null;
+}
+
+export interface AdminNgoRaw {
+  id: string;
+  name: string;
+  mission: string;
+  services: string[];
+  geographic_coverage: string;
+  website: string;
+  contact: { phone?: string; email?: string };
+  cover_image: string;
+  status: NgoStatus;
+  updatedAt: string | null;
+}
+
+export interface AdminClinicRaw {
+  id: string;
+  name: string;
+  provider_type: string;
+  description: string;
+  services: string[];
+  city: string;
+  state: string;
+  opening_hours: string;
+  fee_range: string;
+  website: string;
+  cover_image: string;
+  accepting_new_patients: boolean;
+  contact: { phone?: string; email?: string; address?: string };
+  status: ContentStatus;
+  updatedAt: string | null;
+}
+
+export interface AdminResourcesListResponse {
+  status: string;
+  data: { resources: AdminResourceRaw[] };
+}
+
+export interface AdminLifestyleListResponse {
+  status: string;
+  data: { lifestyle: AdminLifestyleRaw[] };
+}
+
+export interface AdminNgosListResponse {
+  status: string;
+  data: { ngos: AdminNgoRaw[] };
+}
+
+export interface AdminClinicsListResponse {
+  status: string;
+  data: { clinics: AdminClinicRaw[] };
+}
+
+export interface AdminResourceDetailResponse {
+  status: string;
+  data: { resource: AdminResourceRaw };
+}
+
+export interface AdminLifestyleDetailResponse {
+  status: string;
+  data: { lifestyle: AdminLifestyleRaw };
+}
+
+export interface AdminNgoDetailResponse {
+  status: string;
+  data: { ngo: AdminNgoRaw };
+}
+
+export interface AdminClinicDetailResponse {
+  status: string;
+  data: { clinic: AdminClinicRaw };
+}
+
+export interface AdminImageUploadResponse {
+  status: string;
+  data: { imageUrl: string; image_url: string };
+}


### PR DESCRIPTION
## Task Name

Content Manager & Editor Migration

## Summary

Ports the admin content management list view and dynamic multi-type content editor from the legacy client to the migration app. Aligns editor functionality with actual backend capabilities, removes unsupported fields, restores clinic-specific behaviors, disables unsupported NGO creation flows, and updates project documentation to reflect the current Next.js architecture and technology stack.
<img width="1366" height="768" alt="image" src="https://github.com/user-attachments/assets/f9fbb18a-d0a1-4bcb-a68b-e7bc5f7d809e" />

## Linked Issue

Closes #160 

## Checklist

- [x] Targets `migration` and branch follows naming convention
- [x] No console errors and works at 360px width
- [x] Screenshots added (for UI changes)
- [x] Focused PR, non-stigmatizing language