### PR TITLE
Add admin moderation page + Media Edit files

### DIFF
--- a/migration/app/(admin)/admin/media/edit/page.tsx
+++ b/migration/app/(admin)/admin/media/edit/page.tsx
@@ -1,0 +1,10 @@
+
+import MediaEdit from "@/components/admin/MediaEdit";
+
+interface PageProps {
+  params: { id: string };
+}
+
+export default function MediaEditPage({ params }: PageProps) {
+  return <MediaEdit id={params.id} />;
+}

--- a/migration/app/(admin)/admin/moderation/page.tsx
+++ b/migration/app/(admin)/admin/moderation/page.tsx
@@ -1,0 +1,5 @@
+import ModerationClient from "@/components/admin/ModerationClient";
+
+export default function ModerationPage() {
+  return <ModerationClient />;
+}

--- a/migration/components/admin/MediaEdit.tsx
+++ b/migration/components/admin/MediaEdit.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useAdminAuth, clearAdminSessionStorage } from "@/components/admin/UseAdminAuth";
+import api from "@/lib/api";
+
+const API_BASE = "/api/v1/admin/media";
+const BACK_URL = "/admin/moderation?type=media";
+
+
+interface MediaSubmission {
+  id?: string;
+  _id?: string;
+  title?: string;
+  description?: string;
+  email?: string;
+  link?: string;
+  image_url?: string;
+  mediaType?: string;
+  status?: string;
+  submittedAt?: string;
+}
+
+type ActionStatus = "approved" | "rejected" | "removed" | "deleted";
+
+interface FeedbackState {
+  message: string;
+  type: "success" | "error" | "info";
+  visible: boolean;
+}
+
+function MediaEditSkeleton() {
+  return (
+    <div className="story-edit-layout">
+      <div className="story-edit-preview">
+        <div className="skeleton-line" style={{ width: "50%", height: 32, marginBottom: 12 }} />
+        <div className="skeleton-block" style={{ width: "100%", height: 240, borderRadius: 12, marginBottom: 20 }} />
+        <div className="skeleton-line" />
+        <div className="skeleton-line skeleton-line-medium" />
+      </div>
+      <div className="story-edit-panel">
+        <div className="skeleton-line" style={{ width: "60%", height: 24, marginBottom: 20 }} />
+        <div className="skeleton-block" style={{ width: "100%", height: 100, borderRadius: 8 }} />
+      </div>
+    </div>
+  );
+}
+
+
+function FeedbackBanner({ feedback }: { feedback: FeedbackState }) {
+  if (!feedback.visible) return null;
+  return (
+    <div
+      className={`mod-action-feedback mod-feedback-${feedback.type}`}
+      role="status"
+      aria-live="polite"
+    >
+      {feedback.message}
+    </div>
+  );
+}
+
+interface MediaEditProps {
+  id: string;
+}
+
+export default function MediaEdit({ id }: MediaEditProps) {
+  const { user, loading: authLoading } = useAdminAuth();
+
+  const [item, setItem] = useState<MediaSubmission | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actioned, setActioned] = useState(false);
+  const [actionedStatus, setActionedStatus] = useState<ActionStatus | null>(null);
+  const [modNote, setModNote] = useState("");
+  const [notifEmail, setNotifEmail] = useState("");
+  const [rejectMessage, setRejectMessage] = useState("");
+  const [publishDest, setPublishDest] = useState("");
+  const [showRejectField, setShowRejectField] = useState(false);
+  const [buttonsDisabled, setButtonsDisabled] = useState(false);
+  const [savingNote, setSavingNote] = useState(false);
+  const [feedback, setFeedback] = useState<FeedbackState>({
+    message: "",
+    type: "info",
+    visible: false,
+  });
+
+  const showFeedback = useCallback(
+    (message: string, type: FeedbackState["type"]) => {
+      setFeedback({ message, type, visible: true });
+      setTimeout(() => setFeedback((f) => ({ ...f, visible: false })), 5000);
+    },
+    []
+  );
+
+  useEffect(() => {
+    if (!id) {
+      setError("No submission ID provided.");
+      setLoading(false);
+      return;
+    }
+
+    async function fetchItem() {
+      setLoading(true);
+      try {
+        const res = await api.get<{ data?: { item?: MediaSubmission } & MediaSubmission }>(`${API_BASE}/${id}`);
+        const data = res?.data?.item || res?.data || null;
+        setItem(data);
+        if (data?.title) {
+          document.title = `${data.title} — Bloom Admin`;
+        }
+      } catch {
+        setItem({
+          id,
+          title: "Motherhood Unfiltered — Ep. 12",
+          description:
+            "Podcast episode covering lived PPD experiences in West Africa. Very raw and relatable.",
+          email: "nkechi@example.com",
+          link: "https://spotify.com/motherhood",
+          image_url:
+            "https://images.unsplash.com/photo-1478737270239-2f02b77fc618?w=400&q=70",
+          mediaType: "Podcast",
+          status: "pending",
+          submittedAt: new Date().toISOString(),
+        });
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchItem();
+  }, [id]);
+
+  const confirmAction = async (status: ActionStatus) => {
+    const itemId = item?._id || item?.id;
+    if (!itemId) return;
+
+    setButtonsDisabled(true);
+    try {
+      await api.patch(`${API_BASE}/${itemId}`, {
+        status,
+        moderatorNote: modNote || undefined,
+        notificationEmail: notifEmail || undefined,
+        rejectionMessage:
+          status === "rejected" ? rejectMessage || undefined : undefined,
+        publishDestination:
+          status === "approved" && publishDest ? publishDest : undefined,
+      });
+
+      setActionedStatus(status);
+      setActioned(true);
+
+      const message =
+        status === "approved"
+          ? "Approved and queued for publishing."
+          : status === "removed"
+          ? "Submission revoked and marked as removed. Revoke email sent if configured."
+          : status === "deleted"
+          ? "Submission permanently deleted. Permanent delete email sent if configured."
+          : "Rejected.";
+
+      showFeedback(
+        message,
+        status === "approved" ? "success" : status === "deleted" ? "error" : "info"
+      );
+    } catch {
+      setButtonsDisabled(false);
+      showFeedback("Something went wrong.", "error");
+    }
+  };
+
+  const handleRejectClick = () => {
+    if (!showRejectField) {
+      setShowRejectField(true);
+    } else {
+      confirmAction("rejected");
+    }
+  };
+
+  const saveNote = async () => {
+    const itemId = item?._id || item?.id;
+    if (!itemId) return;
+    setSavingNote(true);
+    try {
+      await api.patch(`${API_BASE}/${itemId}`, { moderatorNote: modNote });
+      showFeedback("Note saved.", "success");
+    } catch {
+      showFeedback("Failed to save.", "error");
+    } finally {
+      setSavingNote(false);
+    }
+  };
+
+  const handleLogout = async (btn: HTMLButtonElement) => {
+    btn.disabled = true;
+    try {
+      await api.post("/api/v1/auth/logout");
+    } catch {}
+    clearAdminSessionStorage();
+    window.location.assign("/admin/login");
+  };
+
+  // Auth loading state
+  if (authLoading) {
+    return (
+      <div
+        className="admin-auth-loader visible"
+        id="admin-auth-loader"
+      >
+        <div
+          className="admin-auth-loader-box"
+          role="status"
+          aria-live="polite"
+          aria-label="Checking admin access"
+        >
+          <span className="admin-auth-loader-spinner" aria-hidden="true" />
+          <p>Checking admin access…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) return null;
+
+  const stored = user;
+
+  return (
+    <div className="admin-layout">
+      <div id="sidebar-root"></div>
+
+      <div className="admin-main">
+        <div id="topbar-root"></div>
+
+        <main className="dashboard-content" id="main-content">
+          <a href={BACK_URL} className="mod-back-link">
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <line x1="19" y1="12" x2="5" y2="12" />
+              <polyline points="12 19 5 12 12 5" />
+            </svg>
+            Back to Media Suggestions
+          </a>
+
+          <div id="submission-edit-root" aria-live="polite">
+            {loading ? (
+              <MediaEditSkeleton />
+            ) : error ? null : item ? (
+              <div className="story-edit-layout">
+                <div className="story-edit-preview">
+                  <div className="mod-submission-header">
+                    <h1 className="mod-submission-title">{item.title}</h1>
+                    {item.status && (
+                      <span
+                        id="submission-status-badge"
+                        className={`mod-status-badge mod-status-${actionedStatus ?? item.status}`}
+                      >
+                        {actionedStatus ?? item.status}
+                      </span>
+                    )}
+                  </div>
+
+                  {item.image_url && (
+                    <img
+                      src={item.image_url}
+                      alt={item.title ?? ""}
+                      className="mod-submission-image"
+                      loading="lazy"
+                    />
+                  )}
+
+                  {item.mediaType && (
+                    <p className="mod-submission-meta">
+                      <strong>Type:</strong> {item.mediaType}
+                    </p>
+                  )}
+
+                  {item.description && (
+                    <p className="mod-submission-description">{item.description}</p>
+                  )}
+
+                  {item.link && (
+                    <a
+                      href={item.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mod-submission-link"
+                    >
+                      {item.link}
+                    </a>
+                  )}
+
+                  {item.submittedAt && (
+                    <p className="mod-submission-meta">
+                      <strong>Submitted:</strong>{" "}
+                      {new Date(item.submittedAt).toLocaleDateString("en-GB", {
+                        day: "numeric",
+                        month: "long",
+                        year: "numeric",
+                      })}
+                    </p>
+                  )}
+
+                  {item.email && (
+                    <p className="mod-submission-meta">
+                      <strong>Submitted by:</strong> {item.email}
+                    </p>
+                  )}
+                </div>
+
+                <div className="story-edit-panel">
+                  <FeedbackBanner feedback={feedback} />
+
+                  {actioned ? (
+                    <div id="mod-action-buttons">
+                      <p className="story-edit-already-actioned">
+                        Submission <strong>{actionedStatus}</strong>.{" "}
+                        <a href={BACK_URL} className="mod-back-inline">
+                          Back to list
+                        </a>
+                      </p>
+                    </div>
+                  ) : (
+                    <div id="mod-action-buttons">
+                      <label htmlFor="mod-note" className="mod-label">
+                        Moderator note
+                      </label>
+                      <textarea
+                        id="mod-note"
+                        className="mod-textarea"
+                        value={modNote}
+                        onChange={(e) => setModNote(e.target.value)}
+                        rows={3}
+                        placeholder="Internal note (not sent to submitter)"
+                      />
+                      <button
+                        id="btn-save-note"
+                        className="mod-btn mod-btn-secondary"
+                        onClick={saveNote}
+                        disabled={savingNote}
+                      >
+                        {savingNote ? "Saving…" : "Save note"}
+                      </button>
+
+                      <label htmlFor="notif-email" className="mod-label">
+                        Notification email
+                      </label>
+                      <input
+                        id="notif-email"
+                        type="email"
+                        className="mod-input"
+                        value={notifEmail}
+                        onChange={(e) => setNotifEmail(e.target.value)}
+                        placeholder={item.email ?? ""}
+                      />
+
+                      <label htmlFor="publish-destination" className="mod-label">
+                        Publish destination
+                      </label>
+                      <input
+                        id="publish-destination"
+                        type="text"
+                        className="mod-input"
+                        value={publishDest}
+                        onChange={(e) => setPublishDest(e.target.value)}
+                        placeholder="e.g. resources, blog"
+                      />
+
+                      {showRejectField && (
+                        <div id="reject-message-field">
+                          <label htmlFor="reject-message" className="mod-label">
+                            Rejection message
+                          </label>
+                          <textarea
+                            id="reject-message"
+                            className="mod-textarea"
+                            value={rejectMessage}
+                            onChange={(e) => setRejectMessage(e.target.value)}
+                            rows={3}
+                            placeholder="Reason sent to submitter (optional)"
+                          />
+                        </div>
+                      )}
+
+                      <div className="mod-action-row">
+                        <button
+                          id="btn-approve"
+                          className="mod-btn mod-btn-approve"
+                          onClick={() => confirmAction("approved")}
+                          disabled={buttonsDisabled}
+                        >
+                          Approve
+                        </button>
+
+                        <button
+                          id="btn-reject"
+                          className={`mod-btn mod-btn-reject${
+                            showRejectField ? " mod-btn-reject-confirm" : ""
+                          }`}
+                          onClick={handleRejectClick}
+                          disabled={buttonsDisabled}
+                        >
+                          {showRejectField ? "Confirm Rejection" : "Reject"}
+                        </button>
+
+                        <button
+                          id="btn-revoke"
+                          className="mod-btn mod-btn-revoke"
+                          onClick={() => confirmAction("removed")}
+                          disabled={buttonsDisabled}
+                        >
+                          Revoke
+                        </button>
+
+                        <button
+                          id="btn-delete-post"
+                          className="mod-btn mod-btn-delete"
+                          onClick={() => confirmAction("deleted")}
+                          disabled={buttonsDisabled}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          {error && (
+            <div
+              id="submission-edit-error"
+              className="mod-error-state"
+              role="alert"
+            >
+              <h2>Something went wrong</h2>
+              <p className="mod-error-message">{error}</p>
+              <a href={BACK_URL} className="btn btn-primary">
+                Back to Media
+              </a>
+            </div>
+          )}
+        </main>
+      </div>
+
+      <div id="footer-root"></div>
+    </div>
+  );
+}

--- a/migration/components/admin/ModerationClient.tsx
+++ b/migration/components/admin/ModerationClient.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useAdminAuth } from "@/components/admin/UseAdminAuth";
+import ModerationList from "@/components/admin/ModerationList";
+import type { TypeConfig, ModerationType, Submission } from "@/types/moderation";
+
+function mockClinics(): Submission[] {
+  return [
+    { id: "c1", title: "Grace Medical Centre", description: "Excellent postpartum care in Lagos Island. Staff are very empathetic and experienced with PPD cases.", email: "grace@example.com", location: "Lagos, Nigeria", link: "https://gracemedical.ng", image_url: "https://images.unsplash.com/photo-1519494026892-80bbd2d6fd0d?w=200&q=60", status: "pending", submittedAt: new Date(Date.now() - 1 * 86400000).toISOString() },
+    { id: "c2", title: "Safe Haven Clinic", description: "Specialist postpartum mental health clinic in Abuja. Offers both in-person and virtual sessions.", email: "info@safehaven.ng", location: "Abuja, Nigeria", link: "https://safehaven.ng", image_url: null, status: "pending", submittedAt: new Date(Date.now() - 2 * 86400000).toISOString() },
+    { id: "c3", title: "Bloom Wellness Ibadan", description: "Community-based wellness centre with a dedicated mothers unit.", email: null, location: "Ibadan, Nigeria", link: null, image_url: null, status: "approved", submittedAt: new Date(Date.now() - 5 * 86400000).toISOString() },
+  ];
+}
+
+function mockSpecialists(): Submission[] {
+  return [
+    { id: "s1", title: "Dr. Funmi Adeyemi", description: "Perinatal psychiatrist with 12 years experience. Based in Lagos. Available for in-person and virtual consultations.", email: "funmi@example.com", speciality: "Perinatal Psychiatry", image_url: "https://images.unsplash.com/photo-1594824476967-48c8b964273f?w=200&q=60", status: "pending", submittedAt: new Date(Date.now() - 1 * 86400000).toISOString() },
+    { id: "s2", title: "Dr. Chidi Nwosu", description: "Clinical psychologist specialising in maternal mental health and CBT for postpartum anxiety.", email: "chidi@example.com", speciality: "Clinical Psychology", image_url: null, status: "pending", submittedAt: new Date(Date.now() - 3 * 86400000).toISOString() },
+    { id: "s3", title: "Dr. Amaka Okafor", description: "Obstetrician with a strong focus on mental health screening during and after pregnancy.", email: null, speciality: "Obstetrics", image_url: null, status: "rejected", submittedAt: new Date(Date.now() - 7 * 86400000).toISOString() },
+  ];
+}
+
+function mockMedia(): Submission[] {
+  return [
+    { id: "m1", title: "Motherhood Unfiltered — Ep. 12", description: "Podcast episode covering lived experiences of PPD in West Africa. Very raw and relatable.", email: "nkechi@example.com", link: "https://spotify.com/motherhood", image_url: "https://images.unsplash.com/photo-1478737270239-2f02b77fc618?w=200&q=60", mediaType: "Podcast", status: "pending", submittedAt: new Date(Date.now() - 1 * 86400000).toISOString() },
+    { id: "m2", title: "The Invisible Weight — Article", description: "Long-form article on postpartum depression stigma in Nigerian culture published in The Guardian Nigeria.", email: null, link: "https://guardian.ng/invisible-weight", image_url: null, mediaType: "Article", status: "pending", submittedAt: new Date(Date.now() - 2 * 86400000).toISOString() },
+    { id: "m3", title: "After Baby — Documentary", description: "Short documentary following four mothers through their PPD journeys. Beautifully made.", email: "tolu@example.com", link: "https://youtube.com/afterbaby", image_url: "https://images.unsplash.com/photo-1485846234645-a62644f84728?w=200&q=60", mediaType: "Video", status: "approved", submittedAt: new Date(Date.now() - 4 * 86400000).toISOString() },
+  ];
+}
+
+function mockRequests(): Submission[] {
+  return [
+    { id: "r1", title: "Partnership — Postpartum Support International", description: "We are a global NGO supporting mothers with PPD. We would love to partner with Bloom After to expand our reach in West Africa.", email: "admin@ppsi.org", status: "pending", submittedAt: new Date(Date.now() - 1 * 86400000).toISOString() },
+    { id: "r2", title: "Resource submission — Peer support guide", description: "I have written a practical guide for peer supporters working with PPD mothers. Happy to share it freely.", email: "ada@example.com", status: "pending", submittedAt: new Date(Date.now() - 3 * 86400000).toISOString() },
+    { id: "r3", title: "Speaking request", description: "Requesting that Bloom After participate in our maternal health conference in Accra, November 2026.", email: "events@maternalhealth.org", status: "approved", submittedAt: new Date(Date.now() - 6 * 86400000).toISOString() },
+  ];
+}
+
+const TYPE_CONFIG: Record<ModerationType, TypeConfig> = {
+  clinic: {
+    label: "Clinics",
+    singular: "Clinic",
+    subtitle: "Review and moderate clinic recommendations submitted by the community.",
+    activePageId: "moderation-clinics",
+    editPage: "/admin/clinic/edit",
+    apiEndpoint: "/api/v1/admin/clinics",
+    hasImage: true,
+    hasLink: true,
+    mockItems: mockClinics(),
+  },
+  specialist: {
+    label: "Specialist Onboarding",
+    singular: "Specialist",
+    subtitle: "Review specialists submitted for listing on the platform.",
+    activePageId: "specialists-onboarding",
+    editPage: "/admin/specialist/edit",
+    apiEndpoint: "/api/v1/admin/specialists",
+    hasImage: true,
+    hasLink: false,
+    mockItems: mockSpecialists(),
+  },
+  media: {
+    label: "Media Suggestions",
+    singular: "Media",
+    subtitle: "Review podcasts, articles, and media resources suggested by the community.",
+    activePageId: "media-suggestions",
+    editPage: "/admin/media/edit",
+    apiEndpoint: "/api/v1/admin/media",
+    hasImage: true,
+    hasLink: true,
+    mockItems: mockMedia(),
+  },
+  request: {
+    label: "Other Requests",
+    singular: "Request",
+    subtitle: "Review partnership requests, resource submissions, and other enquiries.",
+    activePageId: "moderation-other",
+    editPage: "/admin/moderation?type=request",
+    apiEndpoint: "/api/v1/admin/requests",
+    hasImage: false,
+    hasLink: false,
+    mockItems: mockRequests(),
+  },
+};
+
+export default function ModerationClient() {
+  const { user, loading: authLoading } = useAdminAuth();
+  const searchParams = useSearchParams();
+  const type = (searchParams.get("type") || "clinic") as ModerationType;
+  const cfg = TYPE_CONFIG[type] ?? TYPE_CONFIG.clinic;
+
+  if (authLoading) {
+    return (
+      <div className="admin-auth-loader visible" id="admin-auth-loader">
+        <div
+          className="admin-auth-loader-box"
+          role="status"
+          aria-live="polite"
+          aria-label="Checking admin access"
+        >
+          <span className="admin-auth-loader-spinner" aria-hidden="true" />
+          <p>Checking admin access…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) return null;
+
+  return (
+    <div className="admin-layout">
+      <div id="sidebar-root"></div>
+
+      <div className="admin-main">
+        <div id="topbar-root"></div>
+
+        <main className="dashboard-content" id="main-content">
+          <ModerationList cfg={cfg} />
+        </main>
+      </div>
+
+      <div id="footer-root"></div>
+    </div>
+  );
+}

--- a/migration/components/admin/ModerationList.tsx
+++ b/migration/components/admin/ModerationList.tsx
@@ -1,0 +1,438 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import api from "@/lib/api";
+import type { Submission, TypeConfig, SubmissionStatus } from "@/types/moderation";
+
+const PAGE_SIZE = 15;
+
+function formatDate(iso?: string): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function ModerationSkeleton() {
+  return (
+    <>
+      {Array.from({ length: 5 }).map((_, i) => (
+        <div
+          key={i}
+          className="mod-submission-card mod-row-skeleton"
+          aria-hidden="true"
+        >
+          <div className="mod-sub-thumb skeleton-block" />
+          <div className="mod-sub-body" style={{ flex: 1 }}>
+            <div className="skeleton-line" style={{ width: "40%", marginBottom: 8 }} />
+            <div className="skeleton-line" style={{ width: "80%" }} />
+            <div className="skeleton-line" style={{ width: "60%" }} />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function StatsPills({ items }: { items: Submission[] }) {
+  const counts = { pending: 0, approved: 0, rejected: 0 };
+  items.forEach((s) => {
+    if (s.status in counts) counts[s.status as keyof typeof counts]++;
+  });
+
+  return (
+    <div id="mod-header-stats" className="mod-header-stats" aria-live="polite">
+      <span className="mod-stat-pill mod-stat-pending">{counts.pending} pending</span>
+      <span className="mod-stat-pill mod-stat-approved">{counts.approved} approved</span>
+      <span className="mod-stat-pill mod-stat-rejected">{counts.rejected} rejected</span>
+    </div>
+  );
+}
+
+interface SubmissionCardProps {
+  item: Submission;
+  cfg: TypeConfig;
+  onAction: (id: string, action: "approve" | "reject") => Promise<void>;
+}
+
+function SubmissionCard({ item, cfg, onAction }: SubmissionCardProps) {
+  const id = item._id || item.id || "";
+  const [acting, setActing] = useState(false);
+
+  const handleAction = async (action: "approve" | "reject") => {
+    setActing(true);
+    await onAction(id, action);
+    setActing(false);
+  };
+
+  return (
+    <article
+      className="mod-submission-card"
+      data-id={id}
+      data-status={item.status}
+    >
+      {/* Thumbnail */}
+      {cfg.hasImage && (
+        item.image_url ? (
+          <img
+            src={item.image_url}
+            alt=""
+            className="mod-sub-thumb"
+            loading="lazy"
+          />
+        ) : (
+          <div className="mod-sub-thumb mod-sub-thumb-placeholder" aria-hidden="true" />
+        )
+      )}
+
+      <div className="mod-sub-body">
+        <div className="mod-sub-top">
+          <div className="mod-sub-meta">
+            <span className="mod-sub-title">{item.title || "Untitled"}</span>
+
+            {/* Type-specific tags */}
+            {(item.speciality || item.mediaType || item.location) && (
+              <div className="mod-sub-tags">
+                {item.speciality && (
+                  <span className="mod-sub-tag">{item.speciality}</span>
+                )}
+                {item.mediaType && (
+                  <span className="mod-sub-tag">{item.mediaType}</span>
+                )}
+                {item.location && (
+                  <span className="mod-sub-tag">{item.location}</span>
+                )}
+              </div>
+            )}
+          </div>
+
+          <div className="mod-sub-right">
+            <span className={`mod-status-badge mod-status-${item.status}`}>
+              {item.status}
+            </span>
+            {item.submittedAt && (
+              <span className="mod-sub-date">{formatDate(item.submittedAt)}</span>
+            )}
+          </div>
+        </div>
+
+        <p className="mod-sub-desc">{item.description || ""}</p>
+
+        <div className="mod-sub-footer">
+          {item.email && (
+            <span className="mod-sub-email">
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <rect x="2" y="4" width="20" height="16" rx="2" />
+                <polyline points="2,4 12,13 22,4" />
+              </svg>
+              {item.email}
+            </span>
+          )}
+
+          {cfg.hasLink && item.link && (
+            <a
+              href={item.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mod-sub-link"
+            >
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                aria-hidden="true"
+              >
+                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                <polyline points="15 3 21 3 21 9" />
+                <line x1="10" y1="14" x2="21" y2="3" />
+              </svg>
+              View link
+            </a>
+          )}
+        </div>
+      </div>
+
+      <div className="mod-row-actions">
+        <a
+          href={`${cfg.editPage}/${id}`}
+          className="mod-action-btn mod-action-review"
+        >
+          Review
+        </a>
+        {item.status === "pending" && (
+          <>
+            <button
+              className="mod-action-btn mod-action-approve"
+              onClick={() => handleAction("approve")}
+              disabled={acting}
+            >
+              {acting ? "…" : "Approve"}
+            </button>
+            <button
+              className="mod-action-btn mod-action-reject"
+              onClick={() => handleAction("reject")}
+              disabled={acting}
+            >
+              {acting ? "…" : "Reject"}
+            </button>
+          </>
+        )}
+      </div>
+    </article>
+  );
+}
+
+interface ModerationListProps {
+  cfg: TypeConfig;
+}
+
+export default function ModerationList({ cfg }: ModerationListProps) {
+  const [allItems, setAllItems] = useState<Submission[]>([]);
+  const [filtered, setFiltered] = useState<Submission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [currentStatus, setCurrentStatus] = useState<SubmissionStatus | "">("");
+  const [currentQuery, setCurrentQuery] = useState("");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fetch items
+  useEffect(() => {
+    async function fetchItems() {
+      setLoading(true);
+      try {
+        const res = await api.get<{
+          data?: { items?: Submission[]; data?: Submission[] } | Submission[];
+        }>(cfg.apiEndpoint);
+        const data =
+          (res?.data as { items?: Submission[] })?.items ||
+          (res?.data as { data?: Submission[] })?.data ||
+          (Array.isArray(res?.data) ? (res.data as Submission[]) : null);
+
+        if (Array.isArray(data) && data.length) {
+          setAllItems(data);
+        } else {
+          setAllItems(cfg.mockItems);
+        }
+      } catch {
+        setAllItems(cfg.mockItems);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchItems();
+  }, [cfg]);
+
+  // Apply filters whenever allItems, status, or query changes
+  const applyFilters = useCallback(
+    (items: Submission[], status: SubmissionStatus | "", query: string) => {
+      const q = query.toLowerCase().trim();
+      const result = items
+        .filter((item) => {
+          const matchStatus = !status || item.status === status;
+          const matchQuery =
+            !q ||
+            [item.title || "", item.description || "", item.email || ""].some(
+              (f) => f.toLowerCase().includes(q)
+            );
+          return matchStatus && matchQuery;
+        })
+        .sort(
+          (a, b) =>
+            new Date(b.submittedAt || 0).getTime() -
+            new Date(a.submittedAt || 0).getTime()
+        );
+
+      setFiltered(result);
+      setCurrentPage(1);
+    },
+    []
+  );
+
+  useEffect(() => {
+    applyFilters(allItems, currentStatus, currentQuery);
+  }, [allItems, currentStatus, currentQuery, applyFilters]);
+
+  // Inline approve / reject
+  const handleAction = async (id: string, action: "approve" | "reject") => {
+    try {
+      await api.patch(`${cfg.apiEndpoint}/${id}`, {
+        status: action === "approve" ? "approved" : "rejected",
+      });
+      setAllItems((prev) =>
+        prev.map((item) =>
+          (item._id || item.id) === id
+            ? { ...item, status: action === "approve" ? "approved" : "rejected" }
+            : item
+        )
+      );
+    } catch {
+      // button re-enables via local state in SubmissionCard
+    }
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => {
+      setCurrentQuery(e.target.value);
+    }, 250);
+  };
+
+  // Pagination
+  const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
+  const pageItems = filtered.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
+  const STATUS_TABS: { label: string; value: SubmissionStatus | "" }[] = [
+    { label: "All", value: "" },
+    { label: "Pending", value: "pending" },
+    { label: "Approved", value: "approved" },
+    { label: "Rejected", value: "rejected" },
+  ];
+
+  return (
+    <>
+      <div id="mod-list-header">
+        <div className="mod-page-header">
+          <div>
+            <h1 className="mod-page-title">{cfg.label}</h1>
+            <p className="mod-page-subtitle">{cfg.subtitle}</p>
+          </div>
+          <StatsPills items={allItems} />
+        </div>
+      </div>
+
+      <div className="mod-filters" role="tablist" aria-label="Filter by status">
+        {STATUS_TABS.map(({ label, value }) => (
+          <button
+            key={value}
+            className={`mod-filter-tab${currentStatus === value ? " active" : ""}`}
+            role="tab"
+            aria-selected={currentStatus === value}
+            data-status={value}
+            aria-controls="mod-list"
+            onClick={() => setCurrentStatus(value as SubmissionStatus | "")}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mod-search-wrap">
+        <svg
+          className="mod-search-icon"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+        <input
+          type="search"
+          id="mod-search"
+          className="mod-search-input"
+          placeholder="Search submissions…"
+          aria-label="Search submissions"
+          autoComplete="off"
+          onChange={handleSearchChange}
+        />
+      </div>
+
+      <div
+        id="mod-list"
+        className="mod-submission-list"
+        role="tabpanel"
+        aria-live="polite"
+        aria-atomic="false"
+      >
+        {loading ? (
+          <ModerationSkeleton />
+        ) : pageItems.length > 0 ? (
+          pageItems.map((item) => (
+            <SubmissionCard
+              key={item._id || item.id}
+              item={item}
+              cfg={cfg}
+              onAction={handleAction}
+            />
+          ))
+        ) : null}
+      </div>
+
+      {/* Empty state */}
+      {!loading && pageItems.length === 0 && (
+        <p id="mod-empty" className="mod-empty" role="status">
+          {currentQuery || currentStatus
+            ? "No submissions match your search or filter."
+            : "No submissions yet."}
+        </p>
+      )}
+
+      {/* Pagination */}
+      {!loading && totalPages > 1 && (
+        <div id="mod-pagination" className="pagination-wrap" aria-live="polite">
+          <nav className="pagination" aria-label="Submission list pagination">
+            <button
+              className="pagination-btn"
+              onClick={() => {
+                setCurrentPage((p) => p - 1);
+                window.scrollTo({ top: 0, behavior: "smooth" });
+              }}
+              disabled={currentPage === 1}
+            >
+              ← Prev
+            </button>
+
+            <div className="pagination-pages">
+              {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+                <button
+                  key={p}
+                  className={`pagination-page${p === currentPage ? " pagination-page-active" : ""}`}
+                  onClick={() => {
+                    setCurrentPage(p);
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                  }}
+                  aria-current={p === currentPage ? "page" : undefined}
+                >
+                  {p}
+                </button>
+              ))}
+            </div>
+
+            <button
+              className="pagination-btn"
+              onClick={() => {
+                setCurrentPage((p) => p + 1);
+                window.scrollTo({ top: 0, behavior: "smooth" });
+              }}
+              disabled={currentPage === totalPages}
+            >
+              Next →
+            </button>
+          </nav>
+        </div>
+      )}
+    </>
+  );
+}

--- a/migration/components/admin/UseAdminAuth.tsx
+++ b/migration/components/admin/UseAdminAuth.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import api from "@/lib/api";
+
+const ADMIN_USER_KEY = "adminUser";
+const ADMIN_AUTH_VERIFIED_KEY = "adminAuthVerified";
+const ADMIN_TOKEN_KEY = "adminToken";
+
+export interface AdminUser {
+  name?: string;
+  email?: string;
+  isSuperAdmin?: boolean;
+}
+
+export function clearAdminSessionStorage() {
+  sessionStorage.removeItem(ADMIN_USER_KEY);
+  sessionStorage.removeItem(ADMIN_AUTH_VERIFIED_KEY);
+  sessionStorage.removeItem(ADMIN_TOKEN_KEY);
+}
+
+export function getStoredAdminUser(): AdminUser | null {
+  try {
+    const raw = sessionStorage.getItem(ADMIN_USER_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function hasFreshAdminReferrer(): boolean {
+  try {
+    const refPath = new URL(document.referrer).pathname || "";
+    return (
+      Boolean(refPath) &&
+      refPath.startsWith("/admin") &&
+      refPath !== "/admin/login" &&
+      !refPath.startsWith("/admin/accept-invite")
+    );
+  } catch {
+    return false;
+  }
+}
+
+function shouldSkipAuthCheck(): boolean {
+  if (sessionStorage.getItem(ADMIN_AUTH_VERIFIED_KEY) !== "1") return false;
+  return Boolean(getStoredAdminUser());
+}
+
+export function useAdminAuth() {
+  const [user, setUser] = useState<AdminUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function verify() {
+      if (!hasFreshAdminReferrer()) {
+        sessionStorage.removeItem(ADMIN_AUTH_VERIFIED_KEY);
+      }
+
+      if (shouldSkipAuthCheck()) {
+        setUser(getStoredAdminUser());
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const response = await api.get<{ user?: AdminUser; data?: { user?: AdminUser } }>("/api/v1/auth/session");
+        const authedUser = response?.user || response?.data?.user || null;
+
+        if (!authedUser) throw new Error("Missing authenticated user");
+
+        sessionStorage.setItem(ADMIN_USER_KEY, JSON.stringify(authedUser));
+        sessionStorage.setItem(ADMIN_AUTH_VERIFIED_KEY, "1");
+        setUser(authedUser);
+      } catch {
+        clearAdminSessionStorage();
+        window.location.assign("/admin/login");
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    verify();
+  }, []);
+
+  return { user, loading };
+}

--- a/migration/types/moderation.ts
+++ b/migration/types/moderation.ts
@@ -1,0 +1,30 @@
+export type SubmissionStatus = "pending" | "approved" | "rejected" | "removed" | "deleted";
+
+export interface Submission {
+  id?: string;
+  _id?: string;
+  title?: string;
+  description?: string;
+  email?: string;
+  link?: string;
+  image_url?: string | null;
+  status: SubmissionStatus;
+  submittedAt?: string;
+  speciality?: string;
+  mediaType?: string;
+  location?: string;
+}
+
+export interface TypeConfig {
+  label: string;
+  singular: string;
+  subtitle: string;
+  activePageId: string;
+  editPage: string;
+  apiEndpoint: string;
+  hasImage: boolean;
+  hasLink: boolean;
+  mockItems: Submission[];
+}
+
+export type ModerationType = "clinic" | "specialist" | "media" | "request";


### PR DESCRIPTION
## What changed

### Admin - Media Edit
- `app/(admin)/media/edit/page.tsx` - server wrapper for media submission review page
- `components/admin/MediaEditClient.tsx` - full moderation actions: approve, reject, revoke, delete, save note; two-click reject flow; skeleton loading; feedback banner
- `components/admin/UseAdminAuth.ts` - reusable auth hook migrated from adminAuth.js; handles session check, sessionStorage, and redirect to /admin/login on failure

### Admin - Moderation Queue
- `app/(admin)/moderation/page.tsx` - server wrapper for moderation queue
- `components/admin/ModerationClient.tsx` - reads `?type=` from URL, resolves TypeConfig and mock data, handles auth
- `components/admin/ModerationList.tsx` - reusable list component kept in a separate file so it can be dropped into any queue type (clinic, specialist, media, request) without pulling in config or mock data

### Types
- `types/moderation.ts` - Submission, TypeConfig, ModerationType, SubmissionStatus